### PR TITLE
Use Go 1.13 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- "1.12"
+- "1.13"
 env:
   GO111MODULE: "on"
 


### PR DESCRIPTION
It looks like that the [build](https://travis-ci.com/icco/postmortems/builds/134682173) broke because I use the new verb `%w` for error wrapping introduced in Go 1.13.

@icco PTAL