### PR TITLE
Added support for JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ serve       Serve the postmortem files in a small website.
 
  - @dastergon for fixing a bunch of bugs, porting hacky Ruby code to Go, and implementing webserver!
 
-If you would like to find postmortem templates from various companies, you can check on Github at the [postmortem-templates](https://github.com/dastergon/postmortem-templates) repository.
+If you would like to find postmortem templates from various companies, you can check at the [postmortem-templates](https://github.com/dastergon/postmortem-templates) repository on Github .

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repo means to create a public repository of postmortems with annotated meta
 
 If you'd like to contribute, either edit a postmortem file in the data folder, or try to fix an issue.
 
+If you want further process the postmortem metadata files locally, we have a [folder](https://postmortems.app/output/) with all the metadata in JSON format. Please let us know your findings.
+
 ## Tool
 
 ```
@@ -28,3 +30,5 @@ serve       Serve the postmortem files in a small website.
 ## Shoutouts
 
  - @dastergon for fixing a bunch of bugs, porting hacky Ruby code to Go, and implementing webserver!
+
+If you would like to find postmortem templates from various companies, you can check on Github at the [postmortem-templates](https://github.com/dastergon/postmortem-templates) repository.

--- a/postmortem.go
+++ b/postmortem.go
@@ -170,6 +170,7 @@ func (pm *Postmortem) Save(dir string) error {
 
 	fm := template.New("PostmortemTemplate")
 	fm = fm.Funcs(template.FuncMap{"yaml": ToYaml})
+
 	fm, err := fm.Parse(bodyTmpl)
 	if err != nil {
 		return err
@@ -185,5 +186,6 @@ func (pm *Postmortem) Save(dir string) error {
 	}
 
 	log.Printf("saved %+v to %+v", pm, data.String())
+
 	return nil
 }

--- a/postmortem_test.go
+++ b/postmortem_test.go
@@ -48,7 +48,6 @@ func TestParse(t *testing.T) {
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("Parse() returned unexpected results (-got +want):\n%s", diff)
 			}
-
 		})
 	}
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -30,6 +30,7 @@ func New(d *string) http.Handler {
 	r.Get("/", indexHandler)
 	r.Get("/about", aboutPageHandler)
 	r.Get("/postmortem/{id}", postmortemPageHandler)
+	r.Get("/postmortem/{id}.json", postmortemJSONPageHandler)
 	r.Get("/category/{category}", categoryPageHandler)
 	r.Get("/healthz", healthzHandler)
 
@@ -184,6 +185,25 @@ func postmortemPageHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	renderTemplate(w, r, "postmortem.html", page)
+}
+
+func postmortemJSONPageHandler(w http.ResponseWriter, r *http.Request) {
+	pmID := chi.URLParam(r, "id")
+
+	jsonPM := pmID + ".json"
+
+	data, err := ioutil.ReadFile(filepath.Join("output/", jsonPM))
+	if err != nil {
+		log.Println(err.Error())
+		http.Error(w, http.StatusText(404), http.StatusNotFound)
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+
+	if _, err := w.Write(data); err != nil {
+		log.Printf("Error writing response to postmortem JSON request")
+	}
 }
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -27,6 +27,8 @@ func New(d *string) http.Handler {
 	fs := http.FileServer(http.Dir("static"))
 	r.Handle("/*", fs)
 
+	r.Handle("/output/", http.StripPrefix("/output/", http.FileServer(http.Dir("./output"))))
+
 	r.Get("/", indexHandler)
 	r.Get("/about", aboutPageHandler)
 	r.Get("/postmortem/{id}", postmortemPageHandler)

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -91,7 +91,6 @@ func TestLoadPostmortem(t *testing.T) {
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("LoadPostmortem() returned unexpected results (-got +want):\n%s", diff)
 			}
-
 		})
 	}
 }
@@ -137,7 +136,6 @@ func TestLoadPostmortems(t *testing.T) {
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("LoadPostmortems() returned unexpected results (-got +want):\n%s", diff)
 			}
-
 		})
 	}
 }

--- a/templates/about.html
+++ b/templates/about.html
@@ -9,6 +9,11 @@
         and expands on it, trying to add categories, time data, and room for more in-depth analysis.</p>
     <p class="lh-copy">If you'd like to contribute, either edit a postmortem file in the data folder, or try to fix an
         issue.</p>
-    <p class="lh-copy">The repository is <a href="https://github.com/icco/postmortems">available</a> on Github.</p>
+
+    <p class="lh-copy">If you want further process the postmortem metadata files locally, we have a <a href="/output/">folder</a> with all the metadata in JSON format. Please let us know your findings.</p>
+
+    <p class="lh-copy">If you would like to find postmortem templates from various companies, you can check on Github at the <a href="https://github.com/dastergon/postmortem-templates">postmortem-templates</a> repository.</p>
+
+    <p class="lh-copy">The repository of this app is <a href="https://github.com/icco/postmortems">available</a> on Github.</p>
 </article>
 {{end}}

--- a/templates/about.html
+++ b/templates/about.html
@@ -12,7 +12,7 @@
 
     <p class="lh-copy">If you want further process the postmortem metadata files locally, we have a <a href="/output/">folder</a> with all the metadata in JSON format. Please let us know your findings.</p>
 
-    <p class="lh-copy">If you would like to find postmortem templates from various companies, you can check on Github at the <a href="https://github.com/dastergon/postmortem-templates">postmortem-templates</a> repository.</p>
+    <p class="lh-copy">If you would like to find postmortem templates from various companies, you can check at the <a href="https://github.com/dastergon/postmortem-templates">postmortem-templates</a> repository on Github.</p>
 
     <p class="lh-copy">The repository of this app is <a href="https://github.com/icco/postmortems">available</a> on Github.</p>
 </article>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -78,6 +78,7 @@
           {{end}}
         </div>
       </div>
+      <a class="f6 f5-l link bg-animate black-80 hover-bg-lightest-blue dib pa3 ph4-l" href="/output/" title="Home">Download</a>
     </nav>
   </header>
 

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -78,7 +78,7 @@
           {{end}}
         </div>
       </div>
-      <a class="f6 f5-l link bg-animate black-80 hover-bg-lightest-blue dib pa3 ph4-l" href="/output/" title="Home">Download</a>
+      <a class="f6 f5-l link bg-animate black-80 hover-bg-lightest-blue dib pa3 ph4-l" href="/output/" title="Download">Download</a>
     </nav>
   </header>
 

--- a/templates/postmortem.html
+++ b/templates/postmortem.html
@@ -13,8 +13,11 @@
   <p class="lh-copy">
     {{ .Description }}
   </p>
-  <small><a href="{{ .URL }}">Source</a>, <a
-      href="https://github.com/icco/postmortems/blob/master/data/{{ .UUID }}.md">Edit Metadata</a> </small>
+  <small>
+      <a href="{{ .URL }}">Source</a> |
+      <a href="https://github.com/icco/postmortems/blob/master/data/{{ .UUID }}.md">Edit Metadata</a> |
+      <a href="{{ .UUID }}.json">JSON file</a>
+  </small>
   {{ end }}
 </article>
 {{end}}

--- a/tool/main.go
+++ b/tool/main.go
@@ -124,6 +124,7 @@ func usage() {
 
 func newPostmortem(dir string) error {
 	pm := postmortems.New()
+
 	err := survey.Ask(qs, pm)
 	if err == terminal.InterruptErr {
 		fmt.Println("interrupted")


### PR DESCRIPTION
- Added an extra link at the header to access all files in JSON
- Added support to view postmortems in JSON file just by appending .json in the UUID and also access is available as a hyperlink at the bottom of each postmortem page
- Enriched README and about page
- Trivial fixes as suggested from golang-ci

@icco PTAL