### PR TITLE
Bug fix: Allow JSON file access from the FileServer

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -27,7 +27,7 @@ func New(d *string) http.Handler {
 	fs := http.FileServer(http.Dir("static"))
 	r.Handle("/*", fs)
 
-	r.Handle("/output/", http.StripPrefix("/output/", http.FileServer(http.Dir("./output"))))
+	r.Handle("/output/*", http.StripPrefix("/output/", http.FileServer(http.Dir("./output"))))
 
 	r.Get("/", indexHandler)
 	r.Get("/about", aboutPageHandler)


### PR DESCRIPTION
Trying to access the JSON files in the `output/` endpoint I was getting 404s. This PR fixes the behaviour and the files are returned properly.

@icco PTAL