### PR TITLE
Run serve process as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,12 @@ EXPOSE 8080
 
 RUN /go/bin/pm -action=validate
 RUN /go/bin/pm -action=generate
+
+# Drop to a non-root user for the runtime serve process.
+# The validate/generate steps above run as root during the build and
+# create world-readable output that the app user can serve without
+# needing write access.
+RUN adduser -S -u 1001 app
+USER app
+
 CMD /go/bin/pm -action=serve


### PR DESCRIPTION
## Problem

The `Dockerfile` is a single-stage build that stays in the `golang:1.26-alpine` builder image. There was no `USER` directive, so the long-running web server process (`pm -action=serve`) ran as root (UID 0).

**Why this matters**: A single-stage build that serves traffic from the full build environment (Go toolchain, git, musl-dev, etc.) is a larger attack surface than a minimal runtime image. Combined with running as root, any exploit of the HTTP server would immediately grant root access with full toolchain available.

## Fix

The `validate` and `generate` steps during the Docker *build* need root to write files; that is unchanged. After those complete, we add a non-root system user and switch to it for the runtime `CMD`:

```diff
+# Drop to a non-root user for the runtime serve process.
+RUN adduser -S -u 1001 app
+USER app
+
 CMD /go/bin/pm -action=serve
```

The generated files created during build are world-readable by default, so the `app` user can serve them without write access.

## Testing

```bash
docker build -t postmortems-test .
docker run --rm postmortems-test id
# uid=1001(app) gid=65533(nogroup) ...
```

## Audit Note

**Reviewed**: Dockerfile, go.mod, tool/, server/, templates/  
**Found & fixed**: serve process running as root  
**Skipped / future run**: The single-stage build ships the entire Go toolchain into the runtime image (~500 MB+). Converting to a proper multi-stage build would significantly reduce the attack surface and image size — recommended as a follow-up. The `GO111MODULE` env var is obsolete since Go 1.16 and can be removed.
