### PR TITLE
Fix critically short HTTP server timeouts (1s → 30s) and add ReadHeaderTimeout

### DIFF
--- a/tool/main.go
+++ b/tool/main.go
@@ -84,10 +84,12 @@ func Serve() error {
 	log.Infow("Starting up", "host", fmt.Sprintf("http://localhost:%s", port))
 
 	srv := &http.Server{
-		Addr:         ":" + port,
-		Handler:      router,
-		ReadTimeout:  1 * time.Second,
-		WriteTimeout: 1 * time.Second,
+		Addr:              ":" + port,
+		Handler:           router,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	return srv.ListenAndServe()


### PR DESCRIPTION
## Problem

`Serve()` in `tool/main.go` creates an `http.Server` with **1-second `ReadTimeout` and `WriteTimeout`**:

```go
// BEFORE
srv := &http.Server{
    Addr:         ":" + port,
    Handler:      router,
    ReadTimeout:  1 * time.Second,
    WriteTimeout: 1 * time.Second,
}
```

These values are far too aggressive:

1. **ReadTimeout: 1s** — the server drops the TCP connection if the client hasn't finished sending the complete request body within one second. POST requests with non-trivial bodies (e.g. on a slow mobile connection) will fail with a connection reset.
2. **WriteTimeout: 1s** — the server aborts its own response stream after one second. The index page and category pages load all postmortem files synchronously from disk on every request. On a busy host this can take longer than 1 second, causing every page to return a truncated body to the browser.
3. **`ReadHeaderTimeout` is absent** — without it a slow-loris client that trickles its HTTP headers will hold each connection open indefinitely.

## Fix

```go
// AFTER
srv := &http.Server{
    Addr:              ":" + port,
    Handler:           router,
    ReadHeaderTimeout: 5 * time.Second,   // new — slow-loris defence
    ReadTimeout:       30 * time.Second,  // was 1s
    WriteTimeout:      30 * time.Second,  // was 1s
    IdleTimeout:       60 * time.Second,  // new
}
```

The 30-second read/write values match the pattern used across the rest of the fleet (`hello`, `wallpapers`, `artgrabber`) and give enough headroom for disk I/O-heavy handlers while still protecting against runaway connections.

## Testing steps

1. `go build ./...` — must compile cleanly.
2. `./pm -action=serve &` — should start without errors.
3. `curl -v http://localhost:8080/healthz` — should return `200 ok.` within 30s.
4. To verify the previous breakage: apply the old 1s timeouts, run `./pm -action=serve &`, and visit the index page on a slow network — the response will be truncated or fail.

## Audit note

**Reviewed:** `tool/main.go`, `server/handlers.go`, `go.mod`, `Dockerfile`.

**Other findings (not fixed here):**
- `renderTemplate` re-parses templates from disk on every request — negligible on low-traffic sites but worth caching for higher load.
- `blackfriday/v2` is no longer maintained (last release 2020); consider migrating to `goldmark` or `yuin/goldmark` in a future run.
- Dockerfile runs validate/generate as root at build time, then drops to non-root user `app` for serving — acceptable pattern.
- No open `audit/` PRs conflicted with this change.
