### PR TITLE
chore: Add OCI annotation labels for GHCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN /pm -action=validate && /pm -action=generate
 # Final stage
 FROM alpine:3.23
 
+LABEL org.opencontainers.image.source=https://github.com/icco/postmortems
+LABEL org.opencontainers.image.description="Postmortem metadata from danluu/post-mortems."
+LABEL org.opencontainers.image.licenses=GPL-3.0
+
 RUN apk add --no-cache ca-certificates tzdata
 RUN adduser -S -u 1001 app
 


### PR DESCRIPTION
Adds the GitHub-recommended OCI annotation labels to the Dockerfile so that
the GHCR package page links back to this repo and shows description/license.

See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

Labels added to the final image stage:
- `org.opencontainers.image.source`
- `org.opencontainers.image.description`
- `org.opencontainers.image.licenses` (where a recognizable LICENSE exists)