### PR TITLE
feat: render styled HTML 404 page instead of plain text

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -74,8 +74,9 @@ func New(opts Options) http.Handler {
 		r.Method(http.MethodGet, "/metrics", opts.MetricsHandler)
 	}
 
-	fs := http.FileServer(http.Dir("static"))
-	r.Handle("/*", fs)
+	r.NotFound(notFoundHandler)
+	r.MethodNotAllowed(notFoundHandler)
+	r.Handle("/*", staticOrNotFound("static"))
 
 	return otelhttp.NewHandler(r, serverName,
 		otelhttp.WithFilter(func(req *http.Request) bool {
@@ -153,7 +154,7 @@ func renderTemplate(w http.ResponseWriter, r *http.Request, view string, data in
 
 	if _, err := os.Stat(fp); err != nil {
 		if os.IsNotExist(err) {
-			http.NotFound(w, r)
+			notFoundHandler(w, r)
 			return
 		}
 	}
@@ -169,6 +170,50 @@ func renderTemplate(w http.ResponseWriter, r *http.Request, view string, data in
 		l.Errorw("template execute error", "view", view, zap.Error(err))
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 	}
+}
+
+// notFoundHandler writes a styled HTML 404 page using the standard layout.
+// Falls back to plain text if the template fails to load so we always
+// emit some response.
+func notFoundHandler(w http.ResponseWriter, r *http.Request) {
+	l := logging.FromContext(r.Context())
+	lp := filepath.Join("templates", "layout.html")
+	fp := filepath.Join("templates", "404.html")
+
+	tmpl, err := template.ParseFiles(lp, fp)
+	if err != nil {
+		l.Errorw("404 template parse error", zap.Error(err))
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	}
+
+	page := struct {
+		Categories []string
+	}{
+		Categories: postmortems.Categories,
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusNotFound)
+	if err := tmpl.ExecuteTemplate(w, "layout", page); err != nil {
+		l.Errorw("404 template execute error", zap.Error(err))
+	}
+}
+
+// staticOrNotFound serves files from dir, falling back to the styled HTML
+// 404 page when a file does not exist (instead of FileServer's plain text).
+func staticOrNotFound(dir string) http.Handler {
+	fs := http.FileServer(http.Dir(dir))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		clean := filepath.Clean("/" + r.URL.Path)
+		full := filepath.Join(dir, clean)
+		info, err := os.Stat(full)
+		if err != nil || info.IsDir() {
+			notFoundHandler(w, r)
+			return
+		}
+		fs.ServeHTTP(w, r)
+	})
 }
 
 func getPosmortemByCategory(pms []*postmortems.Postmortem, category string) []postmortems.Postmortem {
@@ -231,7 +276,7 @@ func postmortemPageHandler(dir string) http.HandlerFunc {
 		pm, err := LoadPostmortem(dir, pmID+".md")
 		if err != nil {
 			l.Warnw("load postmortem", "pmid", pmID, zap.Error(err))
-			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			notFoundHandler(w, r)
 			return
 		}
 

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -82,6 +83,75 @@ func TestMetricsEndpoint(t *testing.T) {
 			t.Errorf("metrics body missing %q\nbody:\n%s", want, text)
 		}
 	}
+}
+
+func TestNotFoundHandler(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Logf("chdir back: %v", err)
+		}
+	})
+	if err := os.Chdir(".."); err != nil {
+		t.Fatalf("chdir to repo root: %v", err)
+	}
+
+	h := New(Options{Logger: zap.NewNop().Sugar()})
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	t.Run("unknown path returns styled 404", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/this-route-does-not-exist") //nolint:noctx // test
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				t.Logf("close body: %v", err)
+			}
+		}()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", resp.StatusCode)
+		}
+		if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+			t.Errorf("content-type = %q, want text/html", ct)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if !strings.Contains(string(body), "404") || !strings.Contains(string(body), "Not Found") {
+			t.Errorf("body missing 404 marker; got:\n%s", body)
+		}
+		if !strings.Contains(string(body), "Postmortem Index") {
+			t.Errorf("body missing layout header; got:\n%s", body)
+		}
+	})
+
+	t.Run("missing postmortem returns styled 404", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/postmortem/00000000-0000-0000-0000-000000000000") //nolint:noctx // test
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				t.Logf("close body: %v", err)
+			}
+		}()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if !strings.Contains(string(body), "Not Found") {
+			t.Errorf("body missing 404 marker; got:\n%s", body)
+		}
+	})
 }
 
 func TestHealthzCheckHandler(t *testing.T) {

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,9 @@
+{{define "title"}}404 Not Found{{end}}
+
+{{define "body"}}
+<article class="pa3 pa5-ns mw8 center tc">
+    <h1 class="f2 f1-l">404 &mdash; Not Found</h1>
+    <p class="lh-copy">The page you were looking for could not be found. It may have been moved, removed, or never existed at all.</p>
+    <p class="lh-copy">Try heading back to the <a href="/">index</a>, browsing by <a href="/category/postmortem">category</a>, or reading the <a href="/about">about</a> page.</p>
+</article>
+{{end}}


### PR DESCRIPTION
## Summary

- Adds a templates/404.html that reuses layout.html so the 404 looks consistent with the rest of the site (header, nav, categories dropdown, footer).
- Adds a notFoundHandler in server/handlers.go and wires it up via chi NotFound/MethodNotAllowed so unknown routes get the styled page with a 404 status.
- Wraps the static file server in staticOrNotFound so missing files under /* (e.g. /foo) hit the styled 404 instead of http.FileServer plain-text default.
- Replaces http.Error(w, ..., StatusNotFound) in postmortemPageHandler with the new handler so missing postmortem IDs also get the styled page.

## Test Plan

- [x] go build ./...
- [x] go test ./...
- [x] New TestNotFoundHandler covers an unknown route and a missing postmortem ID, asserting status 404, text/html content type, and that the body contains the layout and the 404 marker.

Fixes #30