### PR TITLE
feat: add optional title field to postmortems

### DIFF
--- a/postmortem.go
+++ b/postmortem.go
@@ -20,6 +20,7 @@ import (
 type Postmortem struct {
 	UUID        string    `yaml:"uuid"`
 	URL         string    `yaml:"url"`
+	Title       string    `yaml:"title,omitempty"`
 	StartTime   time.Time `yaml:"start_time,omitempty"`
 	EndTime     time.Time `yaml:"end_time,omitempty"`
 	Categories  []string  `yaml:"categories"`
@@ -76,6 +77,10 @@ func Parse(f io.Reader) (*Postmortem, error) {
 
 	if url, ok := fm["url"].(string); ok {
 		p.URL = url
+	}
+
+	if title, ok := fm["title"].(string); ok {
+		p.Title = title
 	}
 
 	if company, ok := fm["company"].(string); ok {

--- a/postmortem_test.go
+++ b/postmortem_test.go
@@ -3,6 +3,7 @@ package postmortems
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -49,5 +50,30 @@ func TestParse(t *testing.T) {
 				t.Errorf("Parse() returned unexpected results (-got +want):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestParseTitle(t *testing.T) {
+	t.Parallel()
+
+	const body = `---
+uuid: "abc"
+url: "https://example.com/postmortem"
+title: "Example outage of 2024"
+company: "Example Inc"
+categories:
+- postmortem
+
+---
+
+Example body.
+`
+
+	got, err := Parse(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got.Title != "Example outage of 2024" {
+		t.Errorf("Title = %q, want %q", got.Title, "Example outage of 2024")
 	}
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -35,6 +35,7 @@ type Options struct {
 type postmortemView struct {
 	UUID        string
 	URL         string
+	Title       string
 	Company     string
 	Product     string
 	Categories  []string
@@ -45,6 +46,7 @@ func toView(pm *postmortems.Postmortem) postmortemView {
 	return postmortemView{
 		UUID:        pm.UUID,
 		URL:         pm.URL,
+		Title:       pm.Title,
 		Company:     pm.Company,
 		Product:     pm.Product,
 		Categories:  pm.Categories,

--- a/templates/category.html
+++ b/templates/category.html
@@ -7,14 +7,16 @@
     <table class="f6 w-100 mw8 center" cellspacing="0">
       <thead>
         <tr>
-          <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">UUID</th>
+          <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">Title</th>
           <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">Company</th>
         </tr>
       </thead>
       <tbody class="lh-copy">
         {{ range .Postmortems }}
         <tr>
-          <td class="pv3 pr3 bb b--black-20"><a href="/postmortem/{{ .UUID }}">{{ .UUID }}</a></td>
+          <td class="pv3 pr3 bb b--black-20">
+            <a href="/postmortem/{{ .UUID }}">{{ if .Title }}{{ .Title }}{{ else }}{{ .Company }}{{ end }}</a>
+          </td>
           <td class="pv3 pr3 bb b--black-20">{{ .Company }}</td>
         </tr>
         {{end}}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
     <table class="f6 w-100 mw8 center" cellspacing="0">
       <thead>
         <tr>
-          <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">UUID</th>
+          <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">Title</th>
           <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">Company</th>
           <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">Category</th>
         </tr>
@@ -14,7 +14,9 @@
       <tbody class="lh-copy">
         {{ range .Postmortems }}
         <tr>
-          <td class="pv3 pr3 bb b--black-20"><a href="/postmortem/{{ .UUID }}">{{ .UUID }}</a></td>
+          <td class="pv3 pr3 bb b--black-20">
+            <a href="/postmortem/{{ .UUID }}">{{ if .Title }}{{ .Title }}{{ else }}{{ .Company }}{{ end }}</a>
+          </td>
           <td class="pv3 pr3 bb b--black-20">{{ .Company }}</td>
           <td class="pv3 pr3 bb b--black-20">
             {{ range .Categories }}

--- a/templates/postmortem.html
+++ b/templates/postmortem.html
@@ -1,9 +1,12 @@
-{{define "title"}}Postmortem{{end}}
+{{define "title"}}{{ range .Postmortems }}{{ if .Title }}{{ .Title }}{{ else }}{{ .Company }} Postmortem{{ end }}{{ end }}{{end}}
 
 {{define "body"}}
 <article class="pa3 pa5-ns mw8 center">
   {{ range .Postmortems }}
-  <h1 class="f3 f2-m f1-l">{{ .Company }}</h1>
+  <h1 class="f3 f2-m f1-l">{{ if .Title }}{{ .Title }}{{ else }}{{ .Company }}{{ end }}</h1>
+  {{ if .Title }}
+  <h2 class="f5 f4-l fw4 mt0">{{ .Company }}</h2>
+  {{ end }}
   <ul>
     {{ range .Categories }}
     <li><a href="/category/{{ . }}">{{ . }}</a></li>

--- a/tool/main.go
+++ b/tool/main.go
@@ -35,6 +35,10 @@ var (
 			Validate: survey.ComposeValidators(survey.Required, IsURL()),
 		},
 		{
+			Name:   "title",
+			Prompt: &survey.Input{Message: "Title (optional, e.g. \"AWS S3 outage of 2017\")?"},
+		},
+		{
 			Name:      "company",
 			Prompt:    &survey.Input{Message: "Company?"},
 			Validate:  survey.Required,


### PR DESCRIPTION
## Summary

- Adds a Title field to the Postmortem struct (yaml: title, omitempty) and parses it in Parse().
- Adds an optional Title prompt to the new-postmortem survey in tool/main.go.
- Threads Title into the renderer view model.
- Updates index.html and category.html so the first column is a Title that links to the entry, falling back to Company when no title is set.
- Updates postmortem.html to use the title as the H1 and the page title, with the company as a subhead.

Existing entries do not have a title set; they keep rendering with the company name, so no backfill is required.

## Test Plan

- [x] go build ./...
- [x] go test ./... (existing TestParse still passes; new TestParseTitle covers the new field)

Fixes #24