### PR TITLE
feat: surface event date period on index and entry pages

### DIFF
--- a/postmortem.go
+++ b/postmortem.go
@@ -17,6 +17,10 @@ import (
 )
 
 // Postmortem is a postmortem summary plus its metadata.
+//
+// StartTime and EndTime together describe the "Event Date Period" the
+// postmortem is about (the from/to of the incident itself). Either may
+// be the zero value to indicate that bound is unknown.
 type Postmortem struct {
 	UUID        string    `yaml:"uuid"`
 	URL         string    `yaml:"url"`
@@ -26,6 +30,33 @@ type Postmortem struct {
 	Company     string    `yaml:"company"`
 	Product     string    `yaml:"product"`
 	Description string    `yaml:"-"`
+}
+
+// HasEventDates reports whether the postmortem has any event date
+// information (start, end, or both).
+func (pm *Postmortem) HasEventDates() bool {
+	return !pm.StartTime.IsZero() || !pm.EndTime.IsZero()
+}
+
+// EventDatePeriod returns a human-readable rendering of the event
+// from/to dates suitable for display next to a postmortem. Returns the
+// empty string if neither bound is set, so callers (templates) can
+// safely render it unconditionally.
+func (pm *Postmortem) EventDatePeriod() string {
+	const layout = "2006-01-02"
+	s, e := pm.StartTime.UTC(), pm.EndTime.UTC()
+	switch {
+	case pm.StartTime.IsZero() && pm.EndTime.IsZero():
+		return ""
+	case pm.StartTime.IsZero():
+		return "until " + e.Format(layout)
+	case pm.EndTime.IsZero():
+		return s.Format(layout)
+	case s.Format(layout) == e.Format(layout):
+		return s.Format(layout)
+	default:
+		return s.Format(layout) + " \u2013 " + e.Format(layout)
+	}
 }
 
 const categoryPostmortem = "postmortem"
@@ -50,6 +81,33 @@ var (
 	log = logging.Must(logging.NewLogger(Service))
 )
 
+// parseFrontmatterTime accepts the various shapes a YAML scalar can take
+// for a date field (time.Time, an empty/missing value, or a string) and
+// returns the parsed time.Time. The zero time is returned for missing
+// or empty values; this matches the existing on-disk convention of
+// `start_time: ""` meaning "unknown".
+func parseFrontmatterTime(v interface{}) (time.Time, error) {
+	switch x := v.(type) {
+	case nil:
+		return time.Time{}, nil
+	case time.Time:
+		return x, nil
+	case string:
+		if x == "" {
+			return time.Time{}, nil
+		}
+		layouts := []string{time.RFC3339, "2006-01-02", "2006-01-02T15:04:05"}
+		for _, l := range layouts {
+			if t, err := time.Parse(l, x); err == nil {
+				return t, nil
+			}
+		}
+		return time.Time{}, fmt.Errorf("could not parse time %q", x)
+	default:
+		return time.Time{}, fmt.Errorf("unexpected type %T for time field", v)
+	}
+}
+
 // Parse turns an io stream into a Postmortem type.
 func Parse(f io.Reader) (*Postmortem, error) {
 	p := &Postmortem{}
@@ -66,12 +124,16 @@ func Parse(f io.Reader) (*Postmortem, error) {
 		p.UUID = uuid
 	}
 
-	if startTime, ok := fm["start_time"].(time.Time); ok {
-		p.StartTime = startTime
+	if t, err := parseFrontmatterTime(fm["start_time"]); err == nil {
+		p.StartTime = t
+	} else {
+		return nil, fmt.Errorf("start_time: %w", err)
 	}
 
-	if endTime, ok := fm["end_time"].(time.Time); ok {
-		p.EndTime = endTime
+	if t, err := parseFrontmatterTime(fm["end_time"]); err == nil {
+		p.EndTime = t
+	} else {
+		return nil, fmt.Errorf("end_time: %w", err)
 	}
 
 	if url, ok := fm["url"].(string); ok {

--- a/postmortem_test.go
+++ b/postmortem_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -47,6 +48,35 @@ func TestParse(t *testing.T) {
 
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("Parse() returned unexpected results (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestEventDatePeriod(t *testing.T) {
+	t.Parallel()
+
+	mar15 := time.Date(2024, 3, 15, 12, 0, 0, 0, time.UTC)
+	mar15local := time.Date(2024, 3, 15, 23, 30, 0, 0, time.FixedZone("test", 4*60*60))
+	mar20 := time.Date(2024, 3, 20, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name string
+		pm   Postmortem
+		want string
+	}{
+		{name: "both zero", pm: Postmortem{}, want: ""},
+		{name: "only start", pm: Postmortem{StartTime: mar15}, want: "2024-03-15"},
+		{name: "only end", pm: Postmortem{EndTime: mar20}, want: "until 2024-03-20"},
+		{name: "same day", pm: Postmortem{StartTime: mar15, EndTime: mar15local}, want: "2024-03-15"},
+		{name: "range", pm: Postmortem{StartTime: mar15, EndTime: mar20}, want: "2024-03-15 \u2013 2024-03-20"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.pm.EventDatePeriod(); got != tc.want {
+				t.Errorf("EventDatePeriod() = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -33,22 +33,24 @@ type Options struct {
 // postmortemView is a render-layer copy of Postmortem whose Description
 // is template.HTML so html/template emits pre-rendered Markdown verbatim.
 type postmortemView struct {
-	UUID        string
-	URL         string
-	Company     string
-	Product     string
-	Categories  []string
-	Description template.HTML // already sanitised by blackfriday
+	UUID            string
+	URL             string
+	Company         string
+	Product         string
+	Categories      []string
+	EventDatePeriod string
+	Description     template.HTML // already sanitised by blackfriday
 }
 
 func toView(pm *postmortems.Postmortem) postmortemView {
 	return postmortemView{
-		UUID:        pm.UUID,
-		URL:         pm.URL,
-		Company:     pm.Company,
-		Product:     pm.Product,
-		Categories:  pm.Categories,
-		Description: template.HTML(pm.Description), // #nosec G203 -- blackfriday output
+		UUID:            pm.UUID,
+		URL:             pm.URL,
+		Company:         pm.Company,
+		Product:         pm.Product,
+		Categories:      pm.Categories,
+		EventDatePeriod: pm.EventDatePeriod(),
+		Description:     template.HTML(pm.Description), // #nosec G203 -- blackfriday output
 	}
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,6 +8,7 @@
         <tr>
           <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">UUID</th>
           <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">Company</th>
+          <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">Date</th>
           <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">Category</th>
         </tr>
       </thead>
@@ -16,6 +17,7 @@
         <tr>
           <td class="pv3 pr3 bb b--black-20"><a href="/postmortem/{{ .UUID }}">{{ .UUID }}</a></td>
           <td class="pv3 pr3 bb b--black-20">{{ .Company }}</td>
+          <td class="pv3 pr3 bb b--black-20">{{ .EventDatePeriod }}</td>
           <td class="pv3 pr3 bb b--black-20">
             {{ range .Categories }}
             <a href="/category/{{ . }}">{{ . }}</a>

--- a/templates/postmortem.html
+++ b/templates/postmortem.html
@@ -4,6 +4,9 @@
 <article class="pa3 pa5-ns mw8 center">
   {{ range .Postmortems }}
   <h1 class="f3 f2-m f1-l">{{ .Company }}</h1>
+  {{ if .EventDatePeriod }}
+  <p class="lh-copy mt0"><strong>Event date:</strong> {{ .EventDatePeriod }}</p>
+  {{ end }}
   <ul>
     {{ range .Categories }}
     <li><a href="/category/{{ . }}">{{ . }}</a></li>

--- a/validate.go
+++ b/validate.go
@@ -60,6 +60,10 @@ func ValidateFile(filename string) (*Postmortem, error) {
 		}
 	}
 
+	if !p.StartTime.IsZero() && !p.EndTime.IsZero() && p.EndTime.Before(p.StartTime) {
+		return nil, fmt.Errorf("%s: end_time %s is before start_time %s", filename, p.EndTime, p.StartTime)
+	}
+
 	if p.Description == "" {
 		return nil, fmt.Errorf("%s: description is empty", filename)
 	}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,65 @@
+package postmortems
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestValidateFile_EndBeforeStart asserts ValidateFile rejects a
+// postmortem whose end_time is before its start_time.
+func TestValidateFile_EndBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	body := `---
+uuid: "11111111-1111-1111-1111-111111111111"
+url: "https://example.com/incident"
+start_time: 2024-03-20T00:00:00Z
+end_time: 2024-03-15T00:00:00Z
+categories:
+- postmortem
+company: "Example"
+product: ""
+
+---
+
+Description.
+`
+	fp := filepath.Join(dir, "11111111-1111-1111-1111-111111111111.md")
+	if err := os.WriteFile(fp, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := ValidateFile(fp); err == nil {
+		t.Fatalf("ValidateFile: want error, got nil")
+	}
+}
+
+// TestValidateFile_EmptyDatesAllowed asserts that empty (zero) start
+// and end times do not fail validation.
+func TestValidateFile_EmptyDatesAllowed(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	body := `---
+uuid: "22222222-2222-2222-2222-222222222222"
+url: "https://example.com/incident"
+categories:
+- postmortem
+company: "Example"
+product: ""
+
+---
+
+Description.
+`
+	fp := filepath.Join(dir, "22222222-2222-2222-2222-222222222222.md")
+	if err := os.WriteFile(fp, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := ValidateFile(fp); err != nil {
+		t.Fatalf("ValidateFile: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- start_time and end_time were already on the Postmortem struct but were never parsed (the YAML library returns dates as strings, so the time.Time type assertion always failed) or rendered. This PR makes them work end to end.
- Parses start_time/end_time from YAML strings in RFC3339 or YYYY-MM-DD form via a parseFrontmatterTime helper. Empty/missing values still yield the zero time.
- Adds Postmortem.HasEventDates() and Postmortem.EventDatePeriod() to format the from/to range gracefully (handles zero, only-start, only-end, same-day, and full range cases).
- Validates that end_time is not before start_time when both are set.
- Adds an EventDatePeriod column to the index table and an "Event date" paragraph on the postmortem entry page; both omit themselves when no date is present.

Backfill is intentionally not done; entries with no dates render unchanged.

## Test Plan

- [x] go build ./...
- [x] go test ./... (new TestEventDatePeriod, TestValidateFile_EndBeforeStart, TestValidateFile_EmptyDatesAllowed)
- [x] go run ./tool -action=validate -dir=./data succeeds against the full corpus

Fixes #32