### PR TITLE
feat: support free-form keywords on postmortems

### DIFF
--- a/postmortem.go
+++ b/postmortem.go
@@ -23,6 +23,7 @@ type Postmortem struct {
 	StartTime   time.Time `yaml:"start_time,omitempty"`
 	EndTime     time.Time `yaml:"end_time,omitempty"`
 	Categories  []string  `yaml:"categories"`
+	Keywords    []string  `yaml:"keywords,omitempty"`
 	Company     string    `yaml:"company"`
 	Product     string    `yaml:"product"`
 	Description string    `yaml:"-"`
@@ -90,6 +91,14 @@ func Parse(f io.Reader) (*Postmortem, error) {
 		for _, c := range cats {
 			if cat, ok := c.(string); ok {
 				p.Categories = append(p.Categories, cat)
+			}
+		}
+	}
+
+	if kws, ok := fm["keywords"].([]interface{}); ok {
+		for _, k := range kws {
+			if kw, ok := k.(string); ok {
+				p.Keywords = append(p.Keywords, kw)
 			}
 		}
 	}

--- a/postmortem_test.go
+++ b/postmortem_test.go
@@ -3,6 +3,7 @@ package postmortems
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -49,5 +50,34 @@ func TestParse(t *testing.T) {
 				t.Errorf("Parse() returned unexpected results (-got +want):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestParseKeywords(t *testing.T) {
+	t.Parallel()
+
+	const body = `---
+uuid: "abc"
+url: "https://example.com/postmortem"
+company: "Example Inc"
+categories:
+- postmortem
+keywords:
+- dns
+- eu-west-1
+- "bgp leak"
+
+---
+
+Example body.
+`
+
+	got, err := Parse(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	want := []string{"dns", "eu-west-1", "bgp leak"}
+	if diff := cmp.Diff(got.Keywords, want); diff != "" {
+		t.Errorf("Keywords mismatch (-got +want):\n%s", diff)
 	}
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -38,6 +38,7 @@ type postmortemView struct {
 	Company     string
 	Product     string
 	Categories  []string
+	Keywords    []string
 	Description template.HTML // already sanitised by blackfriday
 }
 
@@ -48,6 +49,7 @@ func toView(pm *postmortems.Postmortem) postmortemView {
 		Company:     pm.Company,
 		Product:     pm.Product,
 		Categories:  pm.Categories,
+		Keywords:    pm.Keywords,
 		Description: template.HTML(pm.Description), // #nosec G203 -- blackfriday output
 	}
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -354,3 +354,13 @@ ul {
         font-size: 2rem;
     }
 }
+
+.keyword {
+    display: inline-block;
+    background-color: #f0f0f0;
+    color: #333;
+    padding: 2px 8px;
+    border-radius: 3px;
+    font-size: .8rem;
+    margin: 0 2px;
+}

--- a/templates/postmortem.html
+++ b/templates/postmortem.html
@@ -13,6 +13,12 @@
   <p class="lh-copy">
     {{ .Description }}
   </p>
+  {{ if .Keywords }}
+  <p class="lh-copy">
+    <strong>Keywords:</strong>
+    {{ range $i, $k := .Keywords }}{{ if $i }}, {{ end }}<span class="keyword">{{ $k }}</span>{{ end }}
+  </p>
+  {{ end }}
   <small>
     <a href="{{ .URL }}" target="_blank">Source</a> |
     <a href="https://github.com/icco/postmortems/blob/master/data/{{ .UUID }}.md" target="_blank">Edit Metadata</a> |

--- a/tool/main.go
+++ b/tool/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -57,6 +58,14 @@ var (
 				Default:  "postmortem",
 				PageSize: len(postmortems.Categories),
 			},
+		},
+		{
+			Name: "keywords",
+			Prompt: &survey.Input{
+				Message: "Keywords (optional, comma-separated):",
+				Help:    "Free-form tags, e.g. \"dns, bgp, eu-west-1\". Leave blank for none.",
+			},
+			Transform: keywordsTransformer,
 		},
 	}
 )
@@ -180,6 +189,39 @@ func newPostmortem(dir string) error {
 	}
 
 	return pm.Save(dir)
+}
+
+// keywordsTransformer turns a comma-separated string entered into a
+// survey.Input into a []string with whitespace trimmed and empty entries
+// dropped, so the result can be assigned directly into the Keywords
+// slice via survey.Ask.
+func keywordsTransformer(ans interface{}) interface{} {
+	str, ok := ans.(string)
+	if !ok {
+		return ans
+	}
+	var out []string
+	for _, raw := range splitAndTrim(str, ",") {
+		if raw == "" {
+			continue
+		}
+		out = append(out, raw)
+	}
+	return out
+}
+
+// splitAndTrim splits s on sep and trims whitespace from each element.
+// Defined here rather than pulling in strings.Split + a loop in two
+// places to keep the keyword handling self-contained.
+func splitAndTrim(s, sep string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, sep)
+	for i, p := range parts {
+		parts[i] = strings.TrimSpace(p)
+	}
+	return parts
 }
 
 // IsURL validates that a value parses as an absolute URL.

--- a/validate.go
+++ b/validate.go
@@ -60,6 +60,12 @@ func ValidateFile(filename string) (*Postmortem, error) {
 		}
 	}
 
+	for _, kw := range p.Keywords {
+		if kw == "" {
+			return nil, fmt.Errorf("%s: keyword is empty", filename)
+		}
+	}
+
 	if p.Description == "" {
 		return nil, fmt.Errorf("%s: description is empty", filename)
 	}


### PR DESCRIPTION
## Summary

- Adds an optional Keywords []string field to the Postmortem struct, parses it from YAML frontmatter (keywords: ...), and threads it through the view model.
- Renders keywords on the postmortem entry page as small pill tags using a new .keyword style.
- The new-postmortem CLI prompt accepts a comma-separated list and stores them as keywords.
- Validation rejects empty keyword strings; missing/empty Keywords slice is fine, so no backfill is required.

This is intentionally minimal: no faceted search UI yet; that is what #9 covers.

## Test Plan

- [x] go build ./...
- [x] go test ./... (new TestParseKeywords)
- [x] go run ./tool -action=validate -dir=./data succeeds against the full corpus

Fixes #33