### PR TITLE
feat: add per-company page

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -68,6 +68,7 @@ func New(opts Options) http.Handler {
 	r.Get("/postmortem/{id}", postmortemPageHandler(opts.Dir))
 	r.Get("/postmortem/{id}.json", postmortemJSONPageHandler)
 	r.Get("/category/{category}", categoryPageHandler(opts.Dir))
+	r.Get("/company/{company}", companyPageHandler(opts.Dir))
 	r.Get("/healthz", healthzHandler)
 
 	if opts.MetricsHandler != nil {
@@ -144,6 +145,12 @@ func LoadPostmortems(dir string) ([]*postmortems.Postmortem, error) {
 	return pms, nil
 }
 
+// templateFuncs are made available to every template parsed by
+// renderTemplate.
+var templateFuncs = template.FuncMap{
+	"companySlug": CompanySlug,
+}
+
 // renderTemplate parses layout.html + view and writes the response.
 // Uses html/template so {{ .Field }} interpolations are HTML-escaped.
 func renderTemplate(w http.ResponseWriter, r *http.Request, view string, data interface{}) {
@@ -158,7 +165,7 @@ func renderTemplate(w http.ResponseWriter, r *http.Request, view string, data in
 		}
 	}
 
-	tmpl, err := template.ParseFiles(lp, fp)
+	tmpl, err := template.New("layout.html").Funcs(templateFuncs).ParseFiles(lp, fp)
 	if err != nil {
 		l.Errorw("template parse error", "view", view, zap.Error(err))
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -181,6 +188,71 @@ func getPosmortemByCategory(pms []*postmortems.Postmortem, category string) []po
 		}
 	}
 	return ctpm
+}
+
+// CompanySlug turns a company name into a URL-safe slug used by the
+// /company/{slug} route. It is exported so templates and tests can
+// consume the same algorithm.
+func CompanySlug(c string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range strings.ToLower(c) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash && b.Len() > 0 {
+				b.WriteRune('-')
+				prevDash = true
+			}
+		}
+	}
+	return strings.TrimRight(b.String(), "-")
+}
+
+func getPostmortemsByCompanySlug(pms []*postmortems.Postmortem, slug string) []postmortems.Postmortem {
+	out := []postmortems.Postmortem{}
+	for _, pm := range pms {
+		if CompanySlug(pm.Company) == slug {
+			out = append(out, *pm)
+		}
+	}
+	return out
+}
+
+func companyPageHandler(dir string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		l := logging.FromContext(r.Context())
+		slug := chi.URLParam(r, "company")
+
+		pms, err := LoadPostmortems(dir)
+		if err != nil {
+			l.Errorw("load postmortems", "company", slug, zap.Error(err))
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
+
+		matches := getPostmortemsByCompanySlug(pms, slug)
+		if len(matches) == 0 {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			return
+		}
+
+		page := struct {
+			Company     string
+			Slug        string
+			Categories  []string
+			Postmortems []postmortems.Postmortem
+		}{
+			Company:     matches[0].Company,
+			Slug:        slug,
+			Categories:  postmortems.Categories,
+			Postmortems: matches,
+		}
+
+		renderTemplate(w, r, "company.html", page)
+	}
 }
 
 func categoryPageHandler(dir string) http.HandlerFunc {

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -224,6 +225,84 @@ func TestLoadPostmortems(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCompanySlug(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in, want string
+	}{
+		{"CCP Games", "ccp-games"},
+		{"Healthcare.gov", "healthcare-gov"},
+		{"Amazon", "amazon"},
+		{"  weird   spaces  ", "weird-spaces"},
+		{"a/b/c", "a-b-c"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := CompanySlug(tc.in); got != tc.want {
+			t.Errorf("CompanySlug(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestCompanyPageHandler(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(cwd); err != nil {
+			t.Logf("chdir back: %v", err)
+		}
+	})
+	if err := os.Chdir(".."); err != nil {
+		t.Fatalf("chdir to repo root: %v", err)
+	}
+
+	h := New(Options{Logger: zap.NewNop().Sugar(), Dir: "testdata"})
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+
+	t.Run("known company returns matches", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/company/ccp-games") //nolint:noctx // test
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				t.Logf("close body: %v", err)
+			}
+		}()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if !strings.Contains(string(body), "CCP Games") {
+			t.Errorf("body missing CCP Games; got:\n%s", body)
+		}
+		if !strings.Contains(string(body), testUUID) {
+			t.Errorf("body missing UUID; got:\n%s", body)
+		}
+	})
+
+	t.Run("unknown company returns 404", func(t *testing.T) {
+		resp, err := http.Get(srv.URL + "/company/does-not-exist") //nolint:noctx // test
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				t.Logf("close body: %v", err)
+			}
+		}()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", resp.StatusCode)
+		}
+	})
 }
 
 func TestGetPosmortemByCategory(t *testing.T) {

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -136,6 +136,7 @@ const (
 	testCompany     = "CCP Games"
 	testCategory    = "postmortem"
 	testDescription = "A typo and a name conflict caused the installer to sometimes delete the *boot.ini* file on installation of an expansion for *EVE Online* - with [consequences.](https://www.youtube.com/watch?v=msXRFJ2ar_E)"
+	amazonCompany   = "Amazon"
 )
 
 func TestLoadPostmortem(t *testing.T) {
@@ -234,7 +235,7 @@ func TestCompanySlug(t *testing.T) {
 	}{
 		{"CCP Games", "ccp-games"},
 		{"Healthcare.gov", "healthcare-gov"},
-		{"Amazon", "amazon"},
+		{amazonCompany, "amazon"},
 		{"  weird   spaces  ", "weird-spaces"},
 		{"a/b/c", "a-b-c"},
 		{"", ""},
@@ -326,7 +327,7 @@ func TestGetPosmortemByCategory(t *testing.T) {
 				&postmortems.Postmortem{
 					UUID:        "0ea35968-4578-408c-b4fd-8c6ccc3501b0",
 					URL:         "http://aws.amazon.com/message/4372T8/",
-					Company:     "Amazon",
+					Company:     amazonCompany,
 					Categories:  []string{"hardware"},
 					Description: "At 10:25pm PDT on June 4, loss of power at an AWS Sydney facility resulting from severe weather in that area lead to disruption to a significant number of instances in an Availability Zone. Due to the signature of the power loss, power  isolation breakers did not engage, resulting in backup energy reserves draining into the degraded power grid.",
 				},
@@ -355,7 +356,7 @@ func TestGetPosmortemByCategory(t *testing.T) {
 				&postmortems.Postmortem{
 					UUID:        "0ea35968-4578-408c-b4fd-8c6ccc3501b0",
 					URL:         "http://aws.amazon.com/message/4372T8/",
-					Company:     "Amazon",
+					Company:     amazonCompany,
 					Categories:  []string{"hardware"},
 					Description: "At 10:25pm PDT on June 4, loss of power at an AWS Sydney facility resulting from severe weather in that area lead to disruption to a significant number of instances in an Availability Zone. Due to the signature of the power loss, power  isolation breakers did not engage, resulting in backup energy reserves draining into the degraded power grid.",
 				},

--- a/templates/company.html
+++ b/templates/company.html
@@ -1,21 +1,26 @@
-{{define "title"}}Category {{ .Category }}{{end}}
+{{define "title"}}{{ .Company }} postmortems{{end}}
 
 {{define "body"}}
 <div class="pa4">
   <div class="overflow-auto">
-    <h1 class="f3 f2-m f1-l mw8 center">{{ .Category }}</h1>
+    <h1 class="f3 f2-m f1-l mw8 center">{{ .Company }}</h1>
+    <p class="lh-copy mw8 center">Postmortems associated with <strong>{{ .Company }}</strong>.</p>
     <table class="f6 w-100 mw8 center" cellspacing="0">
       <thead>
         <tr>
           <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">UUID</th>
-          <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">Company</th>
+          <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">Category</th>
         </tr>
       </thead>
       <tbody class="lh-copy">
         {{ range .Postmortems }}
         <tr>
           <td class="pv3 pr3 bb b--black-20"><a href="/postmortem/{{ .UUID }}">{{ .UUID }}</a></td>
-          <td class="pv3 pr3 bb b--black-20"><a href="/company/{{ companySlug .Company }}">{{ .Company }}</a></td>
+          <td class="pv3 pr3 bb b--black-20">
+            {{ range .Categories }}
+            <a href="/category/{{ . }}">{{ . }}</a>
+            {{end}}
+          </td>
         </tr>
         {{end}}
       </tbody>

--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
         {{ range .Postmortems }}
         <tr>
           <td class="pv3 pr3 bb b--black-20"><a href="/postmortem/{{ .UUID }}">{{ .UUID }}</a></td>
-          <td class="pv3 pr3 bb b--black-20">{{ .Company }}</td>
+          <td class="pv3 pr3 bb b--black-20"><a href="/company/{{ companySlug .Company }}">{{ .Company }}</a></td>
           <td class="pv3 pr3 bb b--black-20">
             {{ range .Categories }}
             <a href="/category/{{ . }}">{{ . }}</a>

--- a/templates/postmortem.html
+++ b/templates/postmortem.html
@@ -3,7 +3,7 @@
 {{define "body"}}
 <article class="pa3 pa5-ns mw8 center">
   {{ range .Postmortems }}
-  <h1 class="f3 f2-m f1-l">{{ .Company }}</h1>
+  <h1 class="f3 f2-m f1-l"><a href="/company/{{ companySlug .Company }}">{{ .Company }}</a></h1>
   <ul>
     {{ range .Categories }}
     <li><a href="/category/{{ . }}">{{ . }}</a></li>


### PR DESCRIPTION
## Summary

- Adds a /company/{slug} route that lists every postmortem for a given company.
- CompanySlug() normalizes a company name to a URL-safe slug (lowercase, non-alphanumerics collapsed to hyphens) so URLs survive spaces and punctuation.
- The slug helper is registered as a template func (companySlug) so the index, category, and entry templates can link to the company page from each company name.
- A new templates/company.html lists the company's postmortems and reuses the existing layout. Unknown company slugs return 404.

## Test Plan

- [x] go build ./...
- [x] go test ./... (new TestCompanySlug, TestCompanyPageHandler covering the happy and 404 paths)

Fixes #25