### PR TITLE
feat: add client-side table sorting on the index

### DIFF
--- a/static/sort-table.js
+++ b/static/sort-table.js
@@ -1,0 +1,84 @@
+// Tiny client-side table sort for the postmortems index.
+//
+// On click of a `.sortable-th`, sorts the parent table's <tbody> rows
+// by the cell text (or `data-sort-value` attribute) of that column,
+// toggling ascending / descending each click.
+(function () {
+  "use strict";
+
+  function sortTable(table, columnIndex, ascending) {
+    var tbody = table.tBodies[0];
+    if (!tbody) return;
+    var rows = Array.prototype.slice.call(tbody.rows);
+
+    rows.sort(function (a, b) {
+      var av = cellValue(a.cells[columnIndex]);
+      var bv = cellValue(b.cells[columnIndex]);
+      if (av < bv) return ascending ? -1 : 1;
+      if (av > bv) return ascending ? 1 : -1;
+      return 0;
+    });
+
+    var frag = document.createDocumentFragment();
+    rows.forEach(function (row) {
+      frag.appendChild(row);
+    });
+    tbody.appendChild(frag);
+  }
+
+  function cellValue(cell) {
+    if (!cell) return "";
+    if (cell.dataset && typeof cell.dataset.sortValue === "string") {
+      return cell.dataset.sortValue.toLowerCase();
+    }
+    return (cell.textContent || "").trim().toLowerCase();
+  }
+
+  function clearArrows(table) {
+    var headers = table.querySelectorAll("th .sort-arrow");
+    headers.forEach(function (el) {
+      el.textContent = "";
+    });
+  }
+
+  function setArrow(th, ascending) {
+    var span = th.querySelector(".sort-arrow");
+    if (!span) return;
+    span.textContent = ascending ? " \u25B2" : " \u25BC";
+  }
+
+  function init() {
+    var tables = document.querySelectorAll("table.sortable");
+    tables.forEach(function (table) {
+      var headers = table.querySelectorAll("th.sortable-th");
+      headers.forEach(function (th, idx) {
+        th.style.cursor = "pointer";
+        th.setAttribute("role", "button");
+        th.setAttribute("tabindex", "0");
+        // Index of this th amongst all ths so sortTable reads the
+        // matching <td>. Allows non-sortable columns before it.
+        var columnIndex = Array.prototype.indexOf.call(th.parentNode.cells, th);
+        var ascending = true;
+        var handler = function () {
+          sortTable(table, columnIndex, ascending);
+          clearArrows(table);
+          setArrow(th, ascending);
+          ascending = !ascending;
+        };
+        th.addEventListener("click", handler);
+        th.addEventListener("keydown", function (ev) {
+          if (ev.key === "Enter" || ev.key === " ") {
+            ev.preventDefault();
+            handler();
+          }
+        });
+      });
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/static/styles.css
+++ b/static/styles.css
@@ -354,3 +354,16 @@ ul {
         font-size: 2rem;
     }
 }
+
+.sortable-th {
+    user-select: none;
+}
+
+.sortable-th:hover {
+    background-color: #f6f6f6;
+}
+
+.sort-arrow {
+    color: #666;
+    font-size: .75rem;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,20 +3,20 @@
 {{define "body"}}
 <div class="pa4">
   <div class="overflow-auto">
-    <table class="f6 w-100 mw8 center" cellspacing="0">
+    <table id="postmortems-table" class="f6 w-100 mw8 center sortable" cellspacing="0">
       <thead>
         <tr>
           <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">UUID</th>
-          <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">Company</th>
-          <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white">Category</th>
+          <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white sortable-th" data-sort-key="company">Company <span class="sort-arrow"></span></th>
+          <th class="fw6 bb b--black-20 tl pb3 pr3 bg-white sortable-th" data-sort-key="category">Category <span class="sort-arrow"></span></th>
         </tr>
       </thead>
       <tbody class="lh-copy">
         {{ range .Postmortems }}
         <tr>
           <td class="pv3 pr3 bb b--black-20"><a href="/postmortem/{{ .UUID }}">{{ .UUID }}</a></td>
-          <td class="pv3 pr3 bb b--black-20">{{ .Company }}</td>
-          <td class="pv3 pr3 bb b--black-20">
+          <td class="pv3 pr3 bb b--black-20" data-sort-value="{{ .Company }}">{{ .Company }}</td>
+          <td class="pv3 pr3 bb b--black-20" data-sort-value="{{ range .Categories }}{{ . }} {{end}}">
             {{ range .Categories }}
             <a href="/category/{{ . }}">{{ . }}</a>
             {{end}}
@@ -28,4 +28,5 @@
     </table>
   </div>
 </div>
+<script src="/sort-table.js"></script>
 {{end}}


### PR DESCRIPTION
## Summary

- Adds a small dependency-free static/sort-table.js that turns Company and Category headers on the index table into buttons. Clicking sorts the table by that column and toggles ascending/descending on subsequent clicks; arrows in the header reflect the current sort.
- Cells use data-sort-value where the displayed text is not the most useful sort key (e.g. categories render as links).
- The script targets any table.sortable with th.sortable-th headers so other tables can opt in later.
- Tiny styling for the sortable header in styles.css.

## Test Plan

- [x] go build ./...
- [x] go test ./...
- [ ] Manual: load /, click Company / Category headers, confirm rows reorder and arrows toggle (recommended to verify in a browser before merge).

Fixes #28