### PR TITLE
feat: add categorize tool and apply its output to data/

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,27 @@ generate    Generate JSON files from the postmortem Markdown files.
 new         Create a new postmortem file.
 validate    Validate the postmortem files in the directory.
 serve       Serve the postmortem files in a small website.
+categorize  Scrape each postmortem's source URL and suggest categories.
 ```
+
+### `categorize`
+
+The `categorize` action fetches each postmortem's source URL and greps
+the response body against a set of regular expressions per category
+(see `tool/categorize.go`). Without `-apply` it runs as a dry-run that
+prints suggestions to stdout. With `-apply` it merges the suggested
+categories back into each Markdown file.
+
+```sh
+# dry run
+go run ./tool -action=categorize
+
+# write suggestions back into ./data/*.md
+go run ./tool -action=categorize -apply
+```
+
+The tool is intentionally a one-shot helper: review the diff before
+committing. There is no automated PR-filing bot.
 
 ## Contributing
 

--- a/data/01494547-7ee9-4169-a0c0-d921fa309d83.md
+++ b/data/01494547-7ee9-4169-a0c0-d921fa309d83.md
@@ -2,6 +2,7 @@
 uuid: 01494547-7ee9-4169-a0c0-d921fa309d83
 url: http://community.eveonline.com/news/dev-blogs/about-the-boot.ini-issue/
 categories:
+- cloud
 - postmortem
 company: CCP Games
 product: ""

--- a/data/018edf27-f738-448d-8c46-947cd3b6d5b0.md
+++ b/data/018edf27-f738-448d-8c46-947cd3b6d5b0.md
@@ -3,6 +3,7 @@ uuid: 018edf27-f738-448d-8c46-947cd3b6d5b0
 url: https://brew.sh/2018/08/05/security-incident-disclosure/
 categories:
 - postmortem
+- security
 company: Homebrew
 product: ""
 

--- a/data/019eb098-9da5-4d2c-a64c-c6498933f165.md
+++ b/data/019eb098-9da5-4d2c-a64c-c6498933f165.md
@@ -2,6 +2,7 @@
 uuid: 019eb098-9da5-4d2c-a64c-c6498933f165
 url: https://www.honeycomb.io/blog/incident-review-designed-failing/
 categories:
+- cloud
 - postmortem
 company: Honeycomb
 product: ""

--- a/data/029b4a8e-0332-4b91-abc3-5f84bdf70094.md
+++ b/data/029b4a8e-0332-4b91-abc3-5f84bdf70094.md
@@ -2,6 +2,9 @@
 uuid: 029b4a8e-0332-4b91-abc3-5f84bdf70094
 url: https://incident.io/blog/intermittent-downtime
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: incident.io
 product: ""

--- a/data/06ceee47-94f1-400b-bf58-7482d740d5e6.md
+++ b/data/06ceee47-94f1-400b-bf58-7482d740d5e6.md
@@ -2,6 +2,7 @@
 uuid: 06ceee47-94f1-400b-bf58-7482d740d5e6
 url: "https://docs.google.com/document/d/1ScqXAdb6BjhsDzCo3qdPYbt1uULzgZqPO8zHeHHarS0/preview?sle=true&hl=en&forcehl=1#heading=h.dfbilqgnc5sf"
 categories:
+- automation
 - postmortem
 company: Gitlab
 product: ""

--- a/data/090ac94f-65d7-49cc-9e5d-1c8c000b2042.md
+++ b/data/090ac94f-65d7-49cc-9e5d-1c8c000b2042.md
@@ -2,6 +2,7 @@
 uuid: 090ac94f-65d7-49cc-9e5d-1c8c000b2042
 url: https://zerodha.com/marketintel/bulletin/229363/post-mortem-of-technical-issue-august-29-2019
 categories:
+- cloud
 - postmortem
 company: Zerodha
 product: ""

--- a/data/097f2292-4ca7-41f4-abdf-585177b99669.md
+++ b/data/097f2292-4ca7-41f4-abdf-585177b99669.md
@@ -2,6 +2,7 @@
 uuid: 097f2292-4ca7-41f4-abdf-585177b99669
 url: https://zerodha.com/marketintel/bulletin/105569/postmortem-trading-and-hanging-orders-on-12th-april-2018
 categories:
+- cloud
 - postmortem
 company: Zerodha
 product: ""

--- a/data/0b69e012-c539-485c-a2c7-b59c50d0650a.md
+++ b/data/0b69e012-c539-485c-a2c7-b59c50d0650a.md
@@ -2,7 +2,12 @@
 uuid: 0b69e012-c539-485c-a2c7-b59c50d0650a
 url: https://www.elastic.co/blog/elastic-cloud-incident-report-feburary-4-2019
 categories:
+- automation
+- cascading-failure
+- cloud
+- config-change
 - postmortem
+- security
 company: Elastic
 product: ""
 

--- a/data/0d052dd0-b663-4a9d-afc6-d7dd3f424b7a.md
+++ b/data/0d052dd0-b663-4a9d-afc6-d7dd3f424b7a.md
@@ -2,7 +2,11 @@
 uuid: 0d052dd0-b663-4a9d-afc6-d7dd3f424b7a
 url: https://status.cloud.google.com/incidents/6PM5mNd43NbMqjCZ5REh
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- time
 company: Google
 product: ""
 

--- a/data/0d5441d3-c69a-4a0a-ab5f-c5ef6e7cc774.md
+++ b/data/0d5441d3-c69a-4a0a-ab5f-c5ef6e7cc774.md
@@ -2,7 +2,10 @@
 uuid: 0d5441d3-c69a-4a0a-ab5f-c5ef6e7cc774
 url: https://razorpay.com/blog/day-of-rds-multi-az-failover/
 categories:
+- cloud
 - postmortem
+- hardware
+- security
 company: Razorpay
 product: ""
 

--- a/data/0d91dc00-9e72-4bb2-9a49-965129d9f13f.md
+++ b/data/0d91dc00-9e72-4bb2-9a49-965129d9f13f.md
@@ -2,6 +2,7 @@
 uuid: 0d91dc00-9e72-4bb2-9a49-965129d9f13f
 url: https://community.eveonline.com/news/dev-blogs/about-the-boot.ini-issue/
 categories:
+- cloud
 - postmortem
 company: CCP Games
 product: ""

--- a/data/0dfe934b-9234-4383-9d1c-de9b860a43d1.md
+++ b/data/0dfe934b-9234-4383-9d1c-de9b860a43d1.md
@@ -2,6 +2,8 @@
 uuid: 0dfe934b-9234-4383-9d1c-de9b860a43d1
 url: https://web.archive.org/web/20210306015541/https://digital.ai/catalyst-blog/subversion-sha1-collision-problem-statement-prevention-and-remediation-options
 categories:
+- automation
+- config-change
 - postmortem
 company: WebKit code repository
 product: ""

--- a/data/0ea35968-4578-408c-b4fd-8c6ccc3501b0.md
+++ b/data/0ea35968-4578-408c-b4fd-8c6ccc3501b0.md
@@ -2,7 +2,11 @@
 uuid: 0ea35968-4578-408c-b4fd-8c6ccc3501b0
 url: http://aws.amazon.com/message/4372T8/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- hardware
 company: Amazon
 product: ""
 

--- a/data/0fb2bbd9-2967-43be-86f8-dec01edc6707.md
+++ b/data/0fb2bbd9-2967-43be-86f8-dec01edc6707.md
@@ -2,6 +2,7 @@
 uuid: 0fb2bbd9-2967-43be-86f8-dec01edc6707
 url: https://googleblog.blogspot.com/2014/01/todays-outage-for-several-google.html
 categories:
+- cloud
 - postmortem
 company: Google
 product: ""

--- a/data/118fcca7-cf5d-4b6d-924a-3cb6cf976f18.md
+++ b/data/118fcca7-cf5d-4b6d-924a-3cb6cf976f18.md
@@ -2,6 +2,7 @@
 uuid: 118fcca7-cf5d-4b6d-924a-3cb6cf976f18
 url: https://web.archive.org/web/20220704223244/https://flowdock-resources.s3.amazonaws.com/legal/Flowdock-RCA-For-Incident-On-2020-04-21.pdf
 categories:
+- cloud
 - postmortem
 company: Flowdock
 product: ""

--- a/data/14b8603f-f0be-4a1e-999c-2e1be929bccd.md
+++ b/data/14b8603f-f0be-4a1e-999c-2e1be929bccd.md
@@ -3,6 +3,7 @@ uuid: 14b8603f-f0be-4a1e-999c-2e1be929bccd
 url: https://status.twilio.com/incidents/wdrlk4qps0z1
 categories:
 - postmortem
+- time
 company: Twilio
 product: ""
 

--- a/data/1c6f32bc-10ed-463a-a52d-763121f74e30.md
+++ b/data/1c6f32bc-10ed-463a-a52d-763121f74e30.md
@@ -2,6 +2,8 @@
 uuid: 1c6f32bc-10ed-463a-a52d-763121f74e30
 url: https://web.archive.org/web/20211201033341/https://codeascraft.com/2012/01/23/solr-bittorrent-index-replication/
 categories:
+- cloud
+- config-change
 - postmortem
 company: Etsy
 product: ""

--- a/data/1f3d306d-cb11-4acb-8118-2733b8acb635.md
+++ b/data/1f3d306d-cb11-4acb-8118-2733b8acb635.md
@@ -2,7 +2,10 @@
 uuid: 1f3d306d-cb11-4acb-8118-2733b8acb635
 url: https://web.archive.org/web/20211015231917/https://blog.cloudflare.com/a-byzantine-failure-in-the-real-world/
 categories:
+- automation
+- cascading-failure
 - postmortem
+- security
 company: Cloudflare
 product: ""
 

--- a/data/20834b0c-3811-4447-bcfe-2e60eeeb6251.md
+++ b/data/20834b0c-3811-4447-bcfe-2e60eeeb6251.md
@@ -2,6 +2,8 @@
 uuid: 20834b0c-3811-4447-bcfe-2e60eeeb6251
 url: https://www.fastly.com/blog/summary-of-june-8-outage
 categories:
+- automation
+- config-change
 - postmortem
 company: Fastly
 product: ""

--- a/data/23713fc8-675d-4de9-9127-7950f10c6131.md
+++ b/data/23713fc8-675d-4de9-9127-7950f10c6131.md
@@ -2,6 +2,7 @@
 uuid: 23713fc8-675d-4de9-9127-7950f10c6131
 url: https://status.pagerduty.com/incidents/vbp7ht2647l8
 categories:
+- automation
 - postmortem
 company: PagerDuty
 product: ""

--- a/data/2590ea48-9ceb-4cb4-a034-49bffacd7b33.md
+++ b/data/2590ea48-9ceb-4cb4-a034-49bffacd7b33.md
@@ -2,6 +2,7 @@
 uuid: 2590ea48-9ceb-4cb4-a034-49bffacd7b33
 url: http://yellerapp.com/posts/2014-08-04-postmortem1.html
 categories:
+- cloud
 - postmortem
 company: Yeller
 product: ""

--- a/data/27a23dcd-6fc8-4990-8982-88bc2f6f03d4.md
+++ b/data/27a23dcd-6fc8-4990-8982-88bc2f6f03d4.md
@@ -2,7 +2,11 @@
 uuid: 27a23dcd-6fc8-4990-8982-88bc2f6f03d4
 url: https://blog.roblox.com/2022/01/roblox-return-to-service-10-28-10-31-2021/
 categories:
+- automation
+- config-change
 - postmortem
+- hardware
+- time
 company: Roblox
 product: ""
 

--- a/data/27d618e6-ec2e-43bc-88fd-25d9bf27a4bc.md
+++ b/data/27d618e6-ec2e-43bc-88fd-25d9bf27a4bc.md
@@ -2,7 +2,11 @@
 uuid: 27d618e6-ec2e-43bc-88fd-25d9bf27a4bc
 url: http://community.eveonline.com/news/dev-blogs/behind-the-scenes-of-a-long-eve-online-downtime/
 categories:
+- cloud
+- config-change
 - postmortem
+- hardware
+- security
 company: CCP Games
 product: ""
 

--- a/data/27f6c123-6c40-4b34-8a22-d120997948d3.md
+++ b/data/27f6c123-6c40-4b34-8a22-d120997948d3.md
@@ -3,6 +3,7 @@ uuid: 27f6c123-6c40-4b34-8a22-d120997948d3
 url: https://lkml.org/lkml/2009/1/2/373
 categories:
 - postmortem
+- time
 company: Linux
 product: ""
 

--- a/data/300cba9e-d50d-45c4-86fd-0142c6cb9101.md
+++ b/data/300cba9e-d50d-45c4-86fd-0142c6cb9101.md
@@ -2,6 +2,9 @@
 uuid: 300cba9e-d50d-45c4-86fd-0142c6cb9101
 url: https://netflixtechblog.com/post-mortem-of-october-22-2012-aws-degradation-efcee3ab40d5
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Netflix
 product: ""

--- a/data/30bde82e-27e3-48da-873b-499ddc119a8f.md
+++ b/data/30bde82e-27e3-48da-873b-499ddc119a8f.md
@@ -2,7 +2,12 @@
 uuid: 30bde82e-27e3-48da-873b-499ddc119a8f
 url: https://www.stackdriver.com/post-mortem-october-23-stackdriver-outage/
 categories:
+- automation
+- cascading-failure
+- cloud
+- config-change
 - postmortem
+- security
 company: Stackdriver
 product: ""
 

--- a/data/31874408-c4e9-4687-94a2-ec1dfdcdf8e2.md
+++ b/data/31874408-c4e9-4687-94a2-ec1dfdcdf8e2.md
@@ -3,6 +3,7 @@ uuid: 31874408-c4e9-4687-94a2-ec1dfdcdf8e2
 url: "https://www.forbes.com/forbes/2000/1113/6613068a.html#6d1bdc036162"
 categories:
 - postmortem
+- security
 company: Sun
 product: ""
 

--- a/data/31abfad1-00e1-4a22-8236-eff74c4e5d3e.md
+++ b/data/31abfad1-00e1-4a22-8236-eff74c4e5d3e.md
@@ -2,7 +2,9 @@
 uuid: 31abfad1-00e1-4a22-8236-eff74c4e5d3e
 url: https://blogs.dropbox.com/tech/2014/01/outage-post-mortem/
 categories:
+- automation
 - postmortem
+- time
 company: Dropbox
 product: ""
 

--- a/data/33d85b0f-0cc7-4b23-89b5-4521347f25c5.md
+++ b/data/33d85b0f-0cc7-4b23-89b5-4521347f25c5.md
@@ -2,6 +2,8 @@
 uuid: 33d85b0f-0cc7-4b23-89b5-4521347f25c5
 url: https://status.cloud.google.com/incident/cloud-networking/19009
 categories:
+- automation
+- cloud
 - postmortem
 company: Google
 product: ""

--- a/data/3435a88e-1b33-447e-9b4e-fda0625db87f.md
+++ b/data/3435a88e-1b33-447e-9b4e-fda0625db87f.md
@@ -2,7 +2,10 @@
 uuid: 3435a88e-1b33-447e-9b4e-fda0625db87f
 url: https://en.wikipedia.org/wiki/Northeast_blackout_of_2003
 categories:
+- cascading-failure
 - postmortem
+- hardware
+- security
 company: FirstEnergy / General Electric
 product: ""
 

--- a/data/34721eea-9a6a-469f-8865-48286476cf29.md
+++ b/data/34721eea-9a6a-469f-8865-48286476cf29.md
@@ -2,6 +2,8 @@
 uuid: 34721eea-9a6a-469f-8865-48286476cf29
 url: https://web.archive.org/web/20220621124002/https://blog.cloudflare.com/cloudflare-outage-on-june-21-2022/
 categories:
+- automation
+- config-change
 - postmortem
 company: Cloudflare
 product: ""

--- a/data/36450ae5-3427-4ebb-ae57-16409643a473.md
+++ b/data/36450ae5-3427-4ebb-ae57-16409643a473.md
@@ -2,6 +2,9 @@
 uuid: 36450ae5-3427-4ebb-ae57-16409643a473
 url: https://status.discordapp.com/incidents/dj3l6lw926kl
 categories:
+- cascading-failure
+- cloud
+- config-change
 - postmortem
 company: Discord
 product: ""

--- a/data/3abfd687-5668-42e9-8c9b-00c07889ad69.md
+++ b/data/3abfd687-5668-42e9-8c9b-00c07889ad69.md
@@ -2,6 +2,9 @@
 uuid: 3abfd687-5668-42e9-8c9b-00c07889ad69
 url: http://aws.amazon.com/message/680587/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Amazon
 product: ""

--- a/data/3c389d32-40ff-464d-ae81-655e85250aa2.md
+++ b/data/3c389d32-40ff-464d-ae81-655e85250aa2.md
@@ -2,7 +2,12 @@
 uuid: 3c389d32-40ff-464d-ae81-655e85250aa2
 url: https://status.cloud.google.com/incidents/1xkAB1KmLrh5g3v9ZEZ7
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- security
+- time
 company: Google
 product: ""
 

--- a/data/3c3e7f35-0238-4c19-b404-b66fc07be4cb.md
+++ b/data/3c3e7f35-0238-4c19-b404-b66fc07be4cb.md
@@ -2,7 +2,11 @@
 uuid: 3c3e7f35-0238-4c19-b404-b66fc07be4cb
 url: https://blog.cloudflare.com/incident-report-on-memory-leak-caused-by-cloudflare-parser-bug/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- security
 company: Cloudflare
 product: ""
 

--- a/data/3ca9020c-e384-4964-98b6-68268d9e42ec.md
+++ b/data/3ca9020c-e384-4964-98b6-68268d9e42ec.md
@@ -2,6 +2,8 @@
 uuid: 3ca9020c-e384-4964-98b6-68268d9e42ec
 url: https://blog.heroku.com/how-i-broke-git-push-heroku-main
 categories:
+- cloud
+- config-change
 - postmortem
 company: Heroku
 product: ""

--- a/data/3d2adf6c-a887-4db4-badf-92987c613a46.md
+++ b/data/3d2adf6c-a887-4db4-badf-92987c613a46.md
@@ -2,6 +2,9 @@
 uuid: 3d2adf6c-a887-4db4-badf-92987c613a46
 url: https://web.archive.org/web/20220430011642/https://www.epicgames.com/fortnite/en-US/news/postmortem-of-service-outage-at-3-4m-ccu
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Epic Games
 product: ""

--- a/data/3e3b9cb1-49a4-40cc-b353-b1cc3ddd0f98.md
+++ b/data/3e3b9cb1-49a4-40cc-b353-b1cc3ddd0f98.md
@@ -2,7 +2,12 @@
 uuid: 3e3b9cb1-49a4-40cc-b353-b1cc3ddd0f98
 url: https://web.archive.org/web/20221029203405/https://www.reddit.com/r/announcements/comments/4y0m56/why_reddit_was_down_on_aug_11/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- security
+- time
 company: Reddit
 product: ""
 

--- a/data/3e8b0d65-84e5-4a4f-bd28-81a2693432d4.md
+++ b/data/3e8b0d65-84e5-4a4f-bd28-81a2693432d4.md
@@ -2,7 +2,11 @@
 uuid: 3e8b0d65-84e5-4a4f-bd28-81a2693432d4
 url: https://gocardless.com/blog/incident-review-api-and-dashboard-outage-on-10th-october/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- hardware
 company: GoCardless
 product: ""
 

--- a/data/3ea986e0-f370-4308-a884-20040cd74914.md
+++ b/data/3ea986e0-f370-4308-a884-20040cd74914.md
@@ -3,6 +3,7 @@ uuid: 3ea986e0-f370-4308-a884-20040cd74914
 url: https://eslint.org/blog/2018/07/postmortem-for-malicious-package-publishes
 categories:
 - postmortem
+- security
 company: ESLint
 product: ""
 

--- a/data/414194f9-fb2c-48b4-a239-eead81523b5d.md
+++ b/data/414194f9-fb2c-48b4-a239-eead81523b5d.md
@@ -3,6 +3,7 @@ uuid: 414194f9-fb2c-48b4-a239-eead81523b5d
 url: https://www.okta.com/blog/2022/03/oktas-investigation-of-the-january-2022-compromise/
 categories:
 - postmortem
+- security
 company: Okta
 product: ""
 

--- a/data/41f95c9f-d248-4a6c-802d-3648022a03dd.md
+++ b/data/41f95c9f-d248-4a6c-802d-3648022a03dd.md
@@ -2,6 +2,8 @@
 uuid: 41f95c9f-d248-4a6c-802d-3648022a03dd
 url: https://blog.heroku.com/april-2022-incident-review
 categories:
+- automation
+- config-change
 - postmortem
 company: Heroku
 product: ""

--- a/data/46457692-ed7e-49df-8a45-d1b3eea8ac46.md
+++ b/data/46457692-ed7e-49df-8a45-d1b3eea8ac46.md
@@ -2,6 +2,7 @@
 uuid: 46457692-ed7e-49df-8a45-d1b3eea8ac46
 url: http://sunnyday.mit.edu/papers/therac.pdf
 categories:
+- cloud
 - postmortem
 company: Therac-25
 product: ""

--- a/data/47d94612-387c-4ce5-beb1-0d0d84fd8eb2.md
+++ b/data/47d94612-387c-4ce5-beb1-0d0d84fd8eb2.md
@@ -3,6 +3,7 @@ uuid: 47d94612-387c-4ce5-beb1-0d0d84fd8eb2
 url: https://web.archive.org/web/20210813020247/https://brew.sh/2018/08/05/security-incident-disclosure/
 categories:
 - postmortem
+- security
 company: Homebrew
 product: ""
 

--- a/data/49335989-cc3b-4f16-bdc6-df79b7f632ea.md
+++ b/data/49335989-cc3b-4f16-bdc6-df79b7f632ea.md
@@ -2,7 +2,11 @@
 uuid: 49335989-cc3b-4f16-bdc6-df79b7f632ea
 url: https://www.datadoghq.com/blog/2020-09-25-infrastructure-connectivity-issue/
 categories:
+- automation
+- cascading-failure
+- cloud
 - postmortem
+- security
 company: DataDog
 product: ""
 

--- a/data/4a4e2060-38cb-4ced-9788-3c4e305a3c3c.md
+++ b/data/4a4e2060-38cb-4ced-9788-3c4e305a3c3c.md
@@ -2,6 +2,7 @@
 uuid: 4a4e2060-38cb-4ced-9788-3c4e305a3c3c
 url: http://users.csc.calpoly.edu/~jdalbey/SWE/Papers/att_collapse.html
 categories:
+- cascading-failure
 - postmortem
 company: AT&T
 product: ""

--- a/data/4ad169d7-0a29-4e67-8900-87b593d18d18.md
+++ b/data/4ad169d7-0a29-4e67-8900-87b593d18d18.md
@@ -1,12 +1,11 @@
 ---
-
-uuid: "4ad169d7-0a29-4e67-8900-87b593d18d18"
-url: "http://support.gliffy.com/entries/98911057--Gliffy-Online-System-Outage"
-start_time: ""
-end_time: ""
+uuid: 4ad169d7-0a29-4e67-8900-87b593d18d18
+url: http://support.gliffy.com/entries/98911057--Gliffy-Online-System-Outage
 categories:
+- automation
+- config-change
 - postmortem
-company: "Gliffy"
+company: Gliffy
 product: ""
 
 ---

--- a/data/4da4ac8a-fb93-426e-9ae7-eb088f115959.md
+++ b/data/4da4ac8a-fb93-426e-9ae7-eb088f115959.md
@@ -2,7 +2,12 @@
 uuid: 4da4ac8a-fb93-426e-9ae7-eb088f115959
 url: https://blog.github.com/2018-10-30-oct21-post-incident-analysis/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- hardware
+- security
 company: GitHub
 product: ""
 

--- a/data/4fc691c5-2853-49c7-8797-a63249067ade.md
+++ b/data/4fc691c5-2853-49c7-8797-a63249067ade.md
@@ -2,6 +2,7 @@
 uuid: 4fc691c5-2853-49c7-8797-a63249067ade
 url: https://www.twilio.com/blog/2013/07/billing-incident-post-mortem-breakdown-analysis-and-root-cause.html
 categories:
+- cloud
 - postmortem
 company: Twilio
 product: ""

--- a/data/50a576ca-3171-417a-b001-50093be2d910.md
+++ b/data/50a576ca-3171-417a-b001-50093be2d910.md
@@ -2,6 +2,7 @@
 uuid: 50a576ca-3171-417a-b001-50093be2d910
 url: https://gocardless.com/blog/zero-downtime-postgres-migrations-the-hard-parts/
 categories:
+- config-change
 - postmortem
 company: GoCardless
 product: ""

--- a/data/513195e1-adfd-4d8d-ad19-2e723988356d.md
+++ b/data/513195e1-adfd-4d8d-ad19-2e723988356d.md
@@ -2,7 +2,10 @@
 uuid: 513195e1-adfd-4d8d-ad19-2e723988356d
 url: https://status.cloud.google.com/incidents/X8SNkK2BPyCrc1sveeiu
 categories:
+- automation
+- cloud
 - postmortem
+- time
 company: Google
 product: ""
 

--- a/data/55f106c4-1b4e-4d02-bae9-ccf07ff223c2.md
+++ b/data/55f106c4-1b4e-4d02-bae9-ccf07ff223c2.md
@@ -2,7 +2,11 @@
 uuid: 55f106c4-1b4e-4d02-bae9-ccf07ff223c2
 url: https://web.archive.org/web/20211019062735/https://www.pagerduty.com/blog/outage-post-mortem-april-13-2013/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- security
 company: Pagerduty
 product: ""
 

--- a/data/5a1083d6-e8cd-410a-b8de-90967b967ac7.md
+++ b/data/5a1083d6-e8cd-410a-b8de-90967b967ac7.md
@@ -2,6 +2,7 @@
 uuid: 5a1083d6-e8cd-410a-b8de-90967b967ac7
 url: https://regmedia.co.uk/2017/02/23/kcl_external_review.pdf
 categories:
+- cloud
 - postmortem
 company: Kings College London
 product: ""

--- a/data/5a99836e-bbde-4dfc-9621-054eac5c5c50.md
+++ b/data/5a99836e-bbde-4dfc-9621-054eac5c5c50.md
@@ -2,6 +2,9 @@
 uuid: 5a99836e-bbde-4dfc-9621-054eac5c5c50
 url: https://azure.microsoft.com/en-us/blog/summary-of-windows-azure-service-disruption-on-feb-29th-2012/
 categories:
+- cascading-failure
+- cloud
+- config-change
 - postmortem
 company: Azure
 product: ""

--- a/data/5b3c17cb-40a7-46dd-bbd0-233fa37a0fd5.md
+++ b/data/5b3c17cb-40a7-46dd-bbd0-233fa37a0fd5.md
@@ -2,10 +2,12 @@
 uuid: 5b3c17cb-40a7-46dd-bbd0-233fa37a0fd5
 url: https://www3.epa.gov/region1/npdes/merrimackstation/pdfs/ar/AR-1165.pdf
 categories:
+- cloud
 - postmortem
+- time
 company: North American Electric Power System
 product: ""
 
 ---
 
- A power outage in Ohio around 1600h EDT cascaded up through a web of systemic vulnerabilities and process failures and resulted in an outage in the power grid affecting ~50,000,000 people for ~4 days in some areas, and caused rolling blackouts in Ontario for about a week thereafter.
+A power outage in Ohio around 1600h EDT cascaded up through a web of systemic vulnerabilities and process failures and resulted in an outage in the power grid affecting ~50,000,000 people for ~4 days in some areas, and caused rolling blackouts in Ontario for about a week thereafter.

--- a/data/5b6ea49a-1478-48dc-9aaf-ccc1cc0556d6.md
+++ b/data/5b6ea49a-1478-48dc-9aaf-ccc1cc0556d6.md
@@ -2,6 +2,7 @@
 uuid: 5b6ea49a-1478-48dc-9aaf-ccc1cc0556d6
 url: https://users.csc.calpoly.edu/~jdalbey/SWE/Papers/att_collapse.html
 categories:
+- cascading-failure
 - postmortem
 company: AT&T
 product: ""

--- a/data/5b73c1c1-8ec4-4901-91f3-0d993f582dd4.md
+++ b/data/5b73c1c1-8ec4-4901-91f3-0d993f582dd4.md
@@ -2,6 +2,7 @@
 uuid: 5b73c1c1-8ec4-4901-91f3-0d993f582dd4
 url: https://hacks.mozilla.org/2019/07/add-ons-outage-post-mortem-result/
 categories:
+- config-change
 - postmortem
 company: Mozilla
 product: ""

--- a/data/5bce5ed8-a675-4b38-8825-5ec0e41e0d1b.md
+++ b/data/5bce5ed8-a675-4b38-8825-5ec0e41e0d1b.md
@@ -2,7 +2,9 @@
 uuid: 5bce5ed8-a675-4b38-8825-5ec0e41e0d1b
 url: https://web.archive.org/web/20220320100036/https://lkml.org/lkml/2012/7/1/203
 categories:
+- cloud
 - postmortem
+- time
 company: Linux
 product: ""
 

--- a/data/5cbc4e4d-d491-4576-a9fe-6f60ca05c9d8.md
+++ b/data/5cbc4e4d-d491-4576-a9fe-6f60ca05c9d8.md
@@ -2,7 +2,9 @@
 uuid: 5cbc4e4d-d491-4576-a9fe-6f60ca05c9d8
 url: https://web.archive.org/web/20211104160742/https://blog.cloudflare.com/how-and-why-the-leap-second-affected-cloudflare-dns/
 categories:
+- cascading-failure
 - postmortem
+- time
 company: Cloudflare
 product: ""
 

--- a/data/5d74f4e6-c6d3-4566-9526-7abc1fed0db0.md
+++ b/data/5d74f4e6-c6d3-4566-9526-7abc1fed0db0.md
@@ -2,7 +2,9 @@
 uuid: 5d74f4e6-c6d3-4566-9526-7abc1fed0db0
 url: https://mailchimp.com/what-we-learned-from-the-recent-mandrill-outage/
 categories:
+- automation
 - postmortem
+- time
 company: Mandrill
 product: ""
 

--- a/data/5d85d316-f0c4-4c1a-81a2-5f89aaad6148.md
+++ b/data/5d85d316-f0c4-4c1a-81a2-5f89aaad6148.md
@@ -2,7 +2,13 @@
 uuid: 5d85d316-f0c4-4c1a-81a2-5f89aaad6148
 url: https://github.com/blog/2106-january-28th-incident-report
 categories:
+- automation
+- cascading-failure
+- cloud
+- config-change
 - postmortem
+- hardware
+- security
 company: GitHub
 product: ""
 

--- a/data/610cfc96-7d75-4c2a-aa06-8e2acb66b521.md
+++ b/data/610cfc96-7d75-4c2a-aa06-8e2acb66b521.md
@@ -2,7 +2,12 @@
 uuid: 610cfc96-7d75-4c2a-aa06-8e2acb66b521
 url: https://blog.cloudflare.com/todays-outage-post-mortem-82515/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- hardware
+- time
 company: Cloudflare
 product: ""
 

--- a/data/61617271-54e4-4f99-9ade-86428b8fe4c3.md
+++ b/data/61617271-54e4-4f99-9ade-86428b8fe4c3.md
@@ -2,7 +2,10 @@
 uuid: 61617271-54e4-4f99-9ade-86428b8fe4c3
 url: https://web.archive.org/web/20181208123409/https://slackhq.com/this-was-not-normal-really
 categories:
+- automation
+- cascading-failure
 - postmortem
+- security
 company: Slack
 product: ""
 

--- a/data/61a94672-b57c-4aaf-8f8e-9004d5a533d2.md
+++ b/data/61a94672-b57c-4aaf-8f8e-9004d5a533d2.md
@@ -2,6 +2,7 @@
 uuid: 61a94672-b57c-4aaf-8f8e-9004d5a533d2
 url: https://support.stripe.com/questions/outage-postmortem-2015-10-08-utc
 categories:
+- cloud
 - postmortem
 company: Stripe
 product: ""

--- a/data/62dd1eda-63e8-4bf5-a5f8-46a222121474.md
+++ b/data/62dd1eda-63e8-4bf5-a5f8-46a222121474.md
@@ -2,6 +2,8 @@
 uuid: 62dd1eda-63e8-4bf5-a5f8-46a222121474
 url: https://circleci.statuspage.io/incidents/hr0mm9xmm3x6
 categories:
+- cascading-failure
+- config-change
 - postmortem
 company: CircleCI
 product: ""

--- a/data/6330a9a4-38ab-43cb-b34d-aba1bddb66bc.md
+++ b/data/6330a9a4-38ab-43cb-b34d-aba1bddb66bc.md
@@ -2,7 +2,11 @@
 uuid: 6330a9a4-38ab-43cb-b34d-aba1bddb66bc
 url: https://status.cloud.google.com/incidents/vLsxuKoRvykNHW3nnhsJ
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- time
 company: Google
 product: ""
 

--- a/data/6452ddab-74c5-4ecf-b004-89c9dad29160.md
+++ b/data/6452ddab-74c5-4ecf-b004-89c9dad29160.md
@@ -2,6 +2,7 @@
 uuid: 6452ddab-74c5-4ecf-b004-89c9dad29160
 url: https://status.mailgun.com/incidents/p9nxxql8g9rh
 categories:
+- config-change
 - postmortem
 company: Mailgun
 product: ""

--- a/data/655ee350-a86f-424b-89c5-f80cc0fe527e.md
+++ b/data/655ee350-a86f-424b-89c5-f80cc0fe527e.md
@@ -2,6 +2,8 @@
 uuid: 655ee350-a86f-424b-89c5-f80cc0fe527e
 url: https://web.archive.org/web/20201202234639/https://medium.com/@florian_7764/technical-post-mortem-of-the-august-incident-82ab4c3d6547
 categories:
+- automation
+- config-change
 - postmortem
 company: Platform.sh
 product: ""

--- a/data/65ef2aac-4cc6-4592-af9b-999694efc917.md
+++ b/data/65ef2aac-4cc6-4592-af9b-999694efc917.md
@@ -2,6 +2,8 @@
 uuid: 65ef2aac-4cc6-4592-af9b-999694efc917
 url: https://hacks.mozilla.org/2022/02/retrospective-and-technical-details-on-the-recent-firefox-outage/
 categories:
+- cloud
+- config-change
 - postmortem
 company: Firefox
 product: ""

--- a/data/6bc6cd0c-5bbd-4278-a7bf-c42cd8174b50.md
+++ b/data/6bc6cd0c-5bbd-4278-a7bf-c42cd8174b50.md
@@ -2,6 +2,9 @@
 uuid: 6bc6cd0c-5bbd-4278-a7bf-c42cd8174b50
 url: https://slack.engineering/slacks-outage-on-january-4th-2021/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Slack
 product: ""

--- a/data/6c7c05d1-637f-49a9-bc6d-120eacad0b46.md
+++ b/data/6c7c05d1-637f-49a9-bc6d-120eacad0b46.md
@@ -2,7 +2,11 @@
 uuid: 6c7c05d1-637f-49a9-bc6d-120eacad0b46
 url: http://aws.amazon.com/message/2329B7/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- hardware
 company: Amazon
 product: ""
 

--- a/data/759650ec-d3c6-41d9-97d5-5a11b0eb6dcf.md
+++ b/data/759650ec-d3c6-41d9-97d5-5a11b0eb6dcf.md
@@ -2,7 +2,10 @@
 uuid: 759650ec-d3c6-41d9-97d5-5a11b0eb6dcf
 url: "https://status.cloud.google.com/incident/compute/15056#5719570367119360"
 categories:
+- cloud
 - postmortem
+- hardware
+- security
 company: Google
 product: ""
 

--- a/data/76f27cf3-b204-40e4-942e-19657614f658.md
+++ b/data/76f27cf3-b204-40e4-942e-19657614f658.md
@@ -2,7 +2,11 @@
 uuid: 76f27cf3-b204-40e4-942e-19657614f658
 url: https://aws.amazon.com/message/680342/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- hardware
 company: Amazon
 product: ""
 

--- a/data/785c5618-a34e-4dfc-bd04-559fc0635b3b.md
+++ b/data/785c5618-a34e-4dfc-bd04-559fc0635b3b.md
@@ -2,6 +2,10 @@
 uuid: 785c5618-a34e-4dfc-bd04-559fc0635b3b
 url: https://www.chef.io/blog/2014/07/10/supermarket-intermittent-unresponsiveness-postmortem/
 categories:
+- automation
+- cascading-failure
+- cloud
+- config-change
 - postmortem
 company: Chef.io
 product: ""

--- a/data/79613fc4-6dc8-4496-a3fd-f4ce96c5b950.md
+++ b/data/79613fc4-6dc8-4496-a3fd-f4ce96c5b950.md
@@ -2,7 +2,12 @@
 uuid: 79613fc4-6dc8-4496-a3fd-f4ce96c5b950
 url: https://www.elastic.co/blog/elastic-cloud-january-18-2019-incident-report
 categories:
+- automation
+- cascading-failure
+- cloud
+- config-change
 - postmortem
+- security
 company: Elastic
 product: ""
 

--- a/data/7ba9335c-25db-4dfc-b0f6-3e6a2aff2244.md
+++ b/data/7ba9335c-25db-4dfc-b0f6-3e6a2aff2244.md
@@ -2,6 +2,9 @@
 uuid: 7ba9335c-25db-4dfc-b0f6-3e6a2aff2244
 url: https://www.honeycomb.io/blog/incident-review-shepherd-cache-delays/
 categories:
+- cascading-failure
+- cloud
+- config-change
 - postmortem
 company: Honeycomb
 product: ""

--- a/data/7f0cc221-46c7-485e-bf6c-1719dc4c4e49.md
+++ b/data/7f0cc221-46c7-485e-bf6c-1719dc4c4e49.md
@@ -2,6 +2,7 @@
 uuid: 7f0cc221-46c7-485e-bf6c-1719dc4c4e49
 url: https://blog.npmjs.org/post/74949623024/2014-01-28-outage-postmortem.html
 categories:
+- cascading-failure
 - postmortem
 company: NPM
 product: ""

--- a/data/80919009-d534-486c-9142-284d27690da0.md
+++ b/data/80919009-d534-486c-9142-284d27690da0.md
@@ -2,7 +2,12 @@
 uuid: 80919009-d534-486c-9142-284d27690da0
 url: https://github.blog/2021-12-01-github-availability-report-november-2021/
 categories:
+- automation
+- cascading-failure
+- cloud
+- config-change
 - postmortem
+- security
 company: Github
 product: ""
 

--- a/data/82216044-3155-403c-9ccc-83dbfcf0e0a5.md
+++ b/data/82216044-3155-403c-9ccc-83dbfcf0e0a5.md
@@ -2,6 +2,7 @@
 uuid: 82216044-3155-403c-9ccc-83dbfcf0e0a5
 url: https://web.archive.org/web/20220403060108/https://status.aws.amazon.com/s3-20080720.html
 categories:
+- cloud
 - postmortem
 company: Amazon
 product: ""

--- a/data/840dff69-8ba6-4a77-b482-9b270d029f10.md
+++ b/data/840dff69-8ba6-4a77-b482-9b270d029f10.md
@@ -2,6 +2,7 @@
 uuid: 840dff69-8ba6-4a77-b482-9b270d029f10
 url: https://web.archive.org/web/20201018145502/http://yellerapp.com/posts/2014-08-04-postmortem1.html
 categories:
+- cloud
 - postmortem
 company: Yeller
 product: ""

--- a/data/848f9263-fe81-4bbc-b0d2-cc1671bb88a5.md
+++ b/data/848f9263-fe81-4bbc-b0d2-cc1671bb88a5.md
@@ -2,6 +2,7 @@
 uuid: 848f9263-fe81-4bbc-b0d2-cc1671bb88a5
 url: https://help.salesforce.com/apex/HTViewSolution?urlname=Root-Cause-Message-for-Disruption-of-Service-on-NA14-May-2016&language=en_US
 categories:
+- cloud
 - postmortem
 company: Salesforce
 product: ""

--- a/data/852f277c-afc3-4e42-97e3-05b71652b36b.md
+++ b/data/852f277c-afc3-4e42-97e3-05b71652b36b.md
@@ -2,6 +2,7 @@
 uuid: 852f277c-afc3-4e42-97e3-05b71652b36b
 url: https://web.archive.org/web/20211006135542/https://blog.cloudflare.com/todays-outage-post-mortem-82515/
 categories:
+- automation
 - postmortem
 company: Cloudflare
 product: ""

--- a/data/86beec9d-3cf5-4cbd-8379-9a04b614f3e4.md
+++ b/data/86beec9d-3cf5-4cbd-8379-9a04b614f3e4.md
@@ -2,7 +2,10 @@
 uuid: 86beec9d-3cf5-4cbd-8379-9a04b614f3e4
 url: https://engineering.heroku.com/blogs/2017-02-15-filesystem-corruption-on-heroku-dynos/
 categories:
+- cloud
+- config-change
 - postmortem
+- security
 company: Heroku
 product: ""
 

--- a/data/87663826-9c04-40cb-9dbd-f340ce60aa72.md
+++ b/data/87663826-9c04-40cb-9dbd-f340ce60aa72.md
@@ -2,7 +2,12 @@
 uuid: 87663826-9c04-40cb-9dbd-f340ce60aa72
 url: http://www.stackdriver.com/post-mortem-october-23-stackdriver-outage/
 categories:
+- automation
+- cascading-failure
+- cloud
+- config-change
 - postmortem
+- security
 company: Stackdriver
 product: ""
 

--- a/data/8d520e9f-0316-4a36-9891-21a3e2918d6c.md
+++ b/data/8d520e9f-0316-4a36-9891-21a3e2918d6c.md
@@ -2,6 +2,9 @@
 uuid: 8d520e9f-0316-4a36-9891-21a3e2918d6c
 url: https://aws.amazon.com/message/11201/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Amazon
 product: ""

--- a/data/8e0d1847-c35b-4d53-896e-43577fdf5eac.md
+++ b/data/8e0d1847-c35b-4d53-896e-43577fdf5eac.md
@@ -2,7 +2,12 @@
 uuid: 8e0d1847-c35b-4d53-896e-43577fdf5eac
 url: https://blog.cloudflare.com/cloudflare-outage-on-july-17-2020/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- hardware
+- security
 company: Cloudflare
 product: ""
 

--- a/data/8ff8dda7-4bd3-40fe-a898-3c39551da461.md
+++ b/data/8ff8dda7-4bd3-40fe-a898-3c39551da461.md
@@ -2,7 +2,12 @@
 uuid: 8ff8dda7-4bd3-40fe-a898-3c39551da461
 url: https://blog.cloudflare.com/details-of-the-cloudflare-outage-on-july-2-2019/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- hardware
+- security
 company: Cloudflare
 product: ""
 

--- a/data/909573e3-5677-481d-beb6-3c5c09bf8867.md
+++ b/data/909573e3-5677-481d-beb6-3c5c09bf8867.md
@@ -2,6 +2,9 @@
 uuid: 909573e3-5677-481d-beb6-3c5c09bf8867
 url: http://blogs.collab.net/subversion/subversion-sha1-collision-problem-statement-prevention-remediation-options
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: WebKit code repository
 product: ""

--- a/data/912b30f3-43b7-4d6d-a03d-322983048e5c.md
+++ b/data/912b30f3-43b7-4d6d-a03d-322983048e5c.md
@@ -2,7 +2,9 @@
 uuid: 912b30f3-43b7-4d6d-a03d-322983048e5c
 url: https://blog.pythonanywhere.com/189/
 categories:
+- cloud
 - postmortem
+- hardware
 company: PythonAnywhere
 product: ""
 

--- a/data/91f1928a-c9cd-4473-a761-dc0b07914b2e.md
+++ b/data/91f1928a-c9cd-4473-a761-dc0b07914b2e.md
@@ -2,7 +2,9 @@
 uuid: 91f1928a-c9cd-4473-a761-dc0b07914b2e
 url: https://web.archive.org/web/20211029020126/https://blog.cloudflare.com/incident-report-on-memory-leak-caused-by-cloudflare-parser-bug/
 categories:
+- config-change
 - postmortem
+- security
 company: Cloudflare
 product: ""
 

--- a/data/91fb1613-e01a-4a07-ba82-928839bc9272.md
+++ b/data/91fb1613-e01a-4a07-ba82-928839bc9272.md
@@ -2,6 +2,7 @@
 uuid: 91fb1613-e01a-4a07-ba82-928839bc9272
 url: https://web.archive.org/web/20151008061104/http://code.google.com/p/chromium/issues/detail?id=165171
 categories:
+- config-change
 - postmortem
 company: Google
 product: ""

--- a/data/922e216e-efe1-4687-a3e7-2398fbdd8dbe.md
+++ b/data/922e216e-efe1-4687-a3e7-2398fbdd8dbe.md
@@ -2,6 +2,9 @@
 uuid: 922e216e-efe1-4687-a3e7-2398fbdd8dbe
 url: https://web.archive.org/web/20211124170124/https://medium.com/making-instapaper/instapaper-outage-cause-recovery-3c32a7e9cc5f
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Instapaper
 product: ""

--- a/data/95f252f8-fef6-40a0-ab98-977f28d3dbba.md
+++ b/data/95f252f8-fef6-40a0-ab98-977f28d3dbba.md
@@ -2,6 +2,7 @@
 uuid: 95f252f8-fef6-40a0-ab98-977f28d3dbba
 url: http://web.archive.org/web/20150404235419/https://stackstatus.net/post/115305251014/outage-postmortem-march-31-2015
 categories:
+- config-change
 - postmortem
 company: Stack Exchange
 product: ""

--- a/data/965912ea-d272-4080-b4e8-ec62155d6cdb.md
+++ b/data/965912ea-d272-4080-b4e8-ec62155d6cdb.md
@@ -2,7 +2,9 @@
 uuid: 965912ea-d272-4080-b4e8-ec62155d6cdb
 url: https://circleci.com/blog/jan-4-2023-incident-report/
 categories:
+- cloud
 - postmortem
+- security
 company: CircleCI
 product: ""
 

--- a/data/98374d95-2925-48bc-b585-1c8e6f952921.md
+++ b/data/98374d95-2925-48bc-b585-1c8e6f952921.md
@@ -2,6 +2,7 @@
 uuid: 98374d95-2925-48bc-b585-1c8e6f952921
 url: https://googleblog.blogspot.com/2009/01/this-site-may-harm-your-computer-on.html
 categories:
+- automation
 - postmortem
 company: Google
 product: ""

--- a/data/99d5650b-6c18-4c33-b5e5-683b10054a7d.md
+++ b/data/99d5650b-6c18-4c33-b5e5-683b10054a7d.md
@@ -2,7 +2,11 @@
 uuid: 99d5650b-6c18-4c33-b5e5-683b10054a7d
 url: https://aws.amazon.com/message/4372T8/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- hardware
 company: Amazon
 product: ""
 

--- a/data/9abb2c8e-c33c-45ea-8699-4ae61f00830e.md
+++ b/data/9abb2c8e-c33c-45ea-8699-4ae61f00830e.md
@@ -2,6 +2,9 @@
 uuid: 9abb2c8e-c33c-45ea-8699-4ae61f00830e
 url: https://aws.amazon.com/message/5467D2/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Amazon
 product: ""

--- a/data/9f912643-516f-4592-8d71-f70c68984c73.md
+++ b/data/9f912643-516f-4592-8d71-f70c68984c73.md
@@ -2,6 +2,7 @@
 uuid: 9f912643-516f-4592-8d71-f70c68984c73
 url: https://blog.etsy.com/news/2012/demystifying-site-outages/
 categories:
+- cloud
 - postmortem
 company: Etsy
 product: ""

--- a/data/a0e252d3-10a6-4345-84c3-f271124e2d7b.md
+++ b/data/a0e252d3-10a6-4345-84c3-f271124e2d7b.md
@@ -2,7 +2,10 @@
 uuid: a0e252d3-10a6-4345-84c3-f271124e2d7b
 url: https://web.archive.org/web/20211006055154/https://blog.cloudflare.com/details-of-the-cloudflare-outage-on-july-2-2019/
 categories:
+- cascading-failure
+- config-change
 - postmortem
+- security
 company: Cloudflare
 product: ""
 

--- a/data/a0f08b74-a805-417d-84a8-d0948e80476c.md
+++ b/data/a0f08b74-a805-417d-84a8-d0948e80476c.md
@@ -2,6 +2,9 @@
 uuid: a0f08b74-a805-417d-84a8-d0948e80476c
 url: https://aws.amazon.com/message/65648/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Amazon
 product: ""

--- a/data/a46ebba4-2d7c-49e6-aa71-0ce989fbff97.md
+++ b/data/a46ebba4-2d7c-49e6-aa71-0ce989fbff97.md
@@ -2,6 +2,9 @@
 uuid: a46ebba4-2d7c-49e6-aa71-0ce989fbff97
 url: https://status.discordapp.com/incidents/qk9cdgnqnhcn
 categories:
+- cascading-failure
+- cloud
+- config-change
 - postmortem
 company: Discord
 product: ""

--- a/data/a50e7b06-2f2c-4d13-a340-9a1e7eed59d7.md
+++ b/data/a50e7b06-2f2c-4d13-a340-9a1e7eed59d7.md
@@ -2,6 +2,10 @@
 uuid: a50e7b06-2f2c-4d13-a340-9a1e7eed59d7
 url: https://slack.engineering/slacks-incident-on-2-22-22/
 categories:
+- automation
+- cascading-failure
+- cloud
+- config-change
 - postmortem
 company: Slack
 product: ""

--- a/data/a551724f-9c21-472c-9901-d74081d75ae4.md
+++ b/data/a551724f-9c21-472c-9901-d74081d75ae4.md
@@ -2,6 +2,8 @@
 uuid: a551724f-9c21-472c-9901-d74081d75ae4
 url: https://status.duo.com/incidents/4w07bmvnt359
 categories:
+- cascading-failure
+- config-change
 - postmortem
 company: Duo
 product: ""

--- a/data/a85a5f3e-1830-4e94-a8bf-b277e4990b07.md
+++ b/data/a85a5f3e-1830-4e94-a8bf-b277e4990b07.md
@@ -2,6 +2,8 @@
 uuid: a85a5f3e-1830-4e94-a8bf-b277e4990b07
 url: "https://status.cloud.google.com/incident/compute/17003#5660850647990272"
 categories:
+- cloud
+- config-change
 - postmortem
 company: Google
 product: ""

--- a/data/ab8222cd-d25f-4ad7-8ab4-c06412d4aac6.md
+++ b/data/ab8222cd-d25f-4ad7-8ab4-c06412d4aac6.md
@@ -2,6 +2,7 @@
 uuid: ab8222cd-d25f-4ad7-8ab4-c06412d4aac6
 url: https://status.pagerduty.com/incidents/70m30bh7qfmx
 categories:
+- automation
 - postmortem
 company: PagerDuty
 product: ""

--- a/data/ac43196d-9cca-4310-b1a5-916322e2a469.md
+++ b/data/ac43196d-9cca-4310-b1a5-916322e2a469.md
@@ -2,7 +2,10 @@
 uuid: ac43196d-9cca-4310-b1a5-916322e2a469
 url: https://status.cloud.google.com/incidents/fmEL9i2fArADKawkZAa2
 categories:
+- automation
+- cloud
 - postmortem
+- time
 company: Google
 product: ""
 

--- a/data/adc3b69d-9cb8-40d7-941c-f63316a72eb6.md
+++ b/data/adc3b69d-9cb8-40d7-941c-f63316a72eb6.md
@@ -2,6 +2,9 @@
 uuid: adc3b69d-9cb8-40d7-941c-f63316a72eb6
 url: https://aws.amazon.com/message/12721/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Amazon
 product: ""

--- a/data/aeca111b-f5bf-4056-b717-ab9159dc24e0.md
+++ b/data/aeca111b-f5bf-4056-b717-ab9159dc24e0.md
@@ -2,6 +2,7 @@
 uuid: aeca111b-f5bf-4056-b717-ab9159dc24e0
 url: https://www.traviscistatus.com/incidents/khzk8bg4p9sy
 categories:
+- config-change
 - postmortem
 company: TravisCI
 product: ""

--- a/data/b20ad40a-51c0-494c-89bc-e01290d46b5f.md
+++ b/data/b20ad40a-51c0-494c-89bc-e01290d46b5f.md
@@ -2,7 +2,9 @@
 uuid: b20ad40a-51c0-494c-89bc-e01290d46b5f
 url: https://www.google.com/appsstatus/dashboard/incidents/k71P8nHp32hgcMSsC3mR
 categories:
+- config-change
 - postmortem
+- time
 company: Google
 product: ""
 

--- a/data/b29ba3ed-e3be-48f0-95b4-979e69ced0ab.md
+++ b/data/b29ba3ed-e3be-48f0-95b4-979e69ced0ab.md
@@ -2,6 +2,9 @@
 uuid: b29ba3ed-e3be-48f0-95b4-979e69ced0ab
 url: https://news.ycombinator.com/item?id=1769761
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Foursquare
 product: ""

--- a/data/b4b5957d-2c5f-4db4-b866-8d82da25bd93.md
+++ b/data/b4b5957d-2c5f-4db4-b866-8d82da25bd93.md
@@ -2,6 +2,7 @@
 uuid: b4b5957d-2c5f-4db4-b866-8d82da25bd93
 url: https://keepthescore.co/blog/posts/deleting_the_production_database/
 categories:
+- config-change
 - postmortem
 company: Keepthescore
 product: ""

--- a/data/b79bbd0b-b4d9-459e-90b6-15cbf95857b2.md
+++ b/data/b79bbd0b-b4d9-459e-90b6-15cbf95857b2.md
@@ -2,6 +2,9 @@
 uuid: b79bbd0b-b4d9-459e-90b6-15cbf95857b2
 url: https://www.atlassian.com/engineering/post-incident-review-april-2022-outage
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Atlassian
 product: ""

--- a/data/be40b5ba-c37f-46d0-8891-febc43941fd0.md
+++ b/data/be40b5ba-c37f-46d0-8891-febc43941fd0.md
@@ -2,7 +2,11 @@
 uuid: be40b5ba-c37f-46d0-8891-febc43941fd0
 url: https://community.eveonline.com/news/dev-blogs/behind-the-scenes-of-a-long-eve-online-downtime/
 categories:
+- cloud
+- config-change
 - postmortem
+- hardware
+- security
 company: CCP Games
 product: ""
 

--- a/data/c0cdbe65-bdf4-4be5-b3a5-0012d23fc1e1.md
+++ b/data/c0cdbe65-bdf4-4be5-b3a5-0012d23fc1e1.md
@@ -2,7 +2,13 @@
 uuid: c0cdbe65-bdf4-4be5-b3a5-0012d23fc1e1
 url: https://blog.cloudflare.com/a-byzantine-failure-in-the-real-world/
 categories:
+- automation
+- cascading-failure
+- cloud
+- config-change
 - postmortem
+- hardware
+- security
 company: Cloudflare
 product: ""
 

--- a/data/c1645aed-bfb6-4da6-82ef-4302d2b44ef7.md
+++ b/data/c1645aed-bfb6-4da6-82ef-4302d2b44ef7.md
@@ -2,6 +2,7 @@
 uuid: c1645aed-bfb6-4da6-82ef-4302d2b44ef7
 url: http://status.mailgun.com/incidents/p9nxxql8g9rh
 categories:
+- config-change
 - postmortem
 company: Mailgun
 product: ""

--- a/data/c50f19f8-6289-405c-a459-1ac32dbd6955.md
+++ b/data/c50f19f8-6289-405c-a459-1ac32dbd6955.md
@@ -2,7 +2,9 @@
 uuid: c50f19f8-6289-405c-a459-1ac32dbd6955
 url: http://web.archive.org/web/20160610080136/https://www.scribd.com/doc/309574927/ShapeShift-Post-Mortem-Public
 categories:
+- config-change
 - postmortem
+- security
 company: Shapeshift
 product: ""
 

--- a/data/c67e3d46-6829-4524-a849-751464295b74.md
+++ b/data/c67e3d46-6829-4524-a849-751464295b74.md
@@ -2,6 +2,9 @@
 uuid: c67e3d46-6829-4524-a849-751464295b74
 url: https://www.honeycomb.io/blog/incident-resolution-september-retrospective/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Honeycomb
 product: ""

--- a/data/c6f9fe9d-a682-428c-8e2c-7b06fb47cc70.md
+++ b/data/c6f9fe9d-a682-428c-8e2c-7b06fb47cc70.md
@@ -2,6 +2,9 @@
 uuid: c6f9fe9d-a682-428c-8e2c-7b06fb47cc70
 url: https://status.cloud.google.com/incident/storage/19002
 categories:
+- cascading-failure
+- cloud
+- config-change
 - postmortem
 company: Google
 product: ""

--- a/data/c73b27f9-5b62-43ee-b89d-734977ab68d0.md
+++ b/data/c73b27f9-5b62-43ee-b89d-734977ab68d0.md
@@ -2,7 +2,11 @@
 uuid: c73b27f9-5b62-43ee-b89d-734977ab68d0
 url: https://status.cloud.google.com/incidents/eo76pxZiDgWVz4z3kmUv
 categories:
+- automation
+- cloud
 - postmortem
+- hardware
+- time
 company: Google
 product: ""
 

--- a/data/c93f42e8-3685-43b0-97dd-72f53fa3e239.md
+++ b/data/c93f42e8-3685-43b0-97dd-72f53fa3e239.md
@@ -3,6 +3,7 @@ uuid: c93f42e8-3685-43b0-97dd-72f53fa3e239
 url: https://lkml.org/lkml/2012/7/1/203
 categories:
 - postmortem
+- time
 company: Linux
 product: ""
 

--- a/data/c990285e-31b4-48e1-b535-bf18869268ad.md
+++ b/data/c990285e-31b4-48e1-b535-bf18869268ad.md
@@ -2,6 +2,10 @@
 uuid: c990285e-31b4-48e1-b535-bf18869268ad
 url: https://building.buildkite.com/outage-post-mortem-for-august-23rd-82b619a3679b
 categories:
+- automation
+- cascading-failure
+- cloud
+- config-change
 - postmortem
 company: Buildkite
 product: ""

--- a/data/ca5bc718-5852-4355-97df-90def0209e53.md
+++ b/data/ca5bc718-5852-4355-97df-90def0209e53.md
@@ -2,6 +2,7 @@
 uuid: ca5bc718-5852-4355-97df-90def0209e53
 url: "https://status.cloud.google.com/incident/compute/17007#5659118702428160"
 categories:
+- cloud
 - postmortem
 company: Google
 product: ""

--- a/data/ca82c550-402b-4abd-942a-163c1b084e52.md
+++ b/data/ca82c550-402b-4abd-942a-163c1b084e52.md
@@ -2,6 +2,7 @@
 uuid: ca82c550-402b-4abd-942a-163c1b084e52
 url: https://assets.publishing.service.gov.uk/media/604f423be90e077fdf88493f/Boeing_737-8K5_G-TAWG_04-21.pdf
 categories:
+- cloud
 - postmortem
 company: TUI
 product: ""

--- a/data/cc1e5d23-573c-450c-9e61-ce71ffc91318.md
+++ b/data/cc1e5d23-573c-450c-9e61-ce71ffc91318.md
@@ -2,7 +2,11 @@
 uuid: cc1e5d23-573c-450c-9e61-ce71ffc91318
 url: https://www.datadoghq.com/blog/2023-03-08-multiregion-infrastructure-connectivity-issue/
 categories:
+- automation
+- cascading-failure
+- cloud
 - postmortem
+- security
 company: Datadog
 product: ""
 

--- a/data/cc87682c-1689-4b23-82e1-aaf3dff8728f.md
+++ b/data/cc87682c-1689-4b23-82e1-aaf3dff8728f.md
@@ -2,7 +2,11 @@
 uuid: cc87682c-1689-4b23-82e1-aaf3dff8728f
 url: https://status.cloud.google.com/incidents/mREMLwZFe3FuLLn3zfTw
 categories:
+- automation
+- cascading-failure
+- cloud
 - postmortem
+- time
 company: Google
 product: ""
 

--- a/data/cd8e3b5f-7b97-4af5-8986-28e2bf663805.md
+++ b/data/cd8e3b5f-7b97-4af5-8986-28e2bf663805.md
@@ -2,7 +2,9 @@
 uuid: cd8e3b5f-7b97-4af5-8986-28e2bf663805
 url: https://wiki.gentoo.org/wiki/Github/2018-06-28
 categories:
+- automation
 - postmortem
+- security
 company: Gentoo
 product: ""
 

--- a/data/cee00e02-03d4-4354-a5a6-ad10b48c812e.md
+++ b/data/cee00e02-03d4-4354-a5a6-ad10b48c812e.md
@@ -2,6 +2,9 @@
 uuid: cee00e02-03d4-4354-a5a6-ad10b48c812e
 url: https://aws.amazon.com/message/680587/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Amazon
 product: ""

--- a/data/d44e5d9b-5c18-4cbe-b624-46bb9a311b84.md
+++ b/data/d44e5d9b-5c18-4cbe-b624-46bb9a311b84.md
@@ -2,6 +2,7 @@
 uuid: d44e5d9b-5c18-4cbe-b624-46bb9a311b84
 url: https://web.archive.org/web/20170728131458/https://kickstarter.engineering/the-day-the-replication-died-e543ba45f262
 categories:
+- cloud
 - postmortem
 company: Kickstarter
 product: ""

--- a/data/d6db1e76-af37-435c-83e9-e7c7cabfaf0f.md
+++ b/data/d6db1e76-af37-435c-83e9-e7c7cabfaf0f.md
@@ -2,7 +2,10 @@
 uuid: d6db1e76-af37-435c-83e9-e7c7cabfaf0f
 url: https://web.archive.org/web/20210818034431/https://medium.com/square-corner-blog/incident-summary-2017-03-16-2f65be39297
 categories:
+- cloud
+- config-change
 - postmortem
+- security
 company: Square
 product: ""
 

--- a/data/d9ae38c1-c5da-4138-9919-5fc5e21a70a9.md
+++ b/data/d9ae38c1-c5da-4138-9919-5fc5e21a70a9.md
@@ -2,6 +2,9 @@
 uuid: d9ae38c1-c5da-4138-9919-5fc5e21a70a9
 url: https://status.cloud.google.com/incident/compute/16007
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Google
 product: ""

--- a/data/dac13e0f-a04b-43fb-89a7-c739424f527d.md
+++ b/data/dac13e0f-a04b-43fb-89a7-c739424f527d.md
@@ -2,7 +2,11 @@
 uuid: dac13e0f-a04b-43fb-89a7-c739424f527d
 url: https://aws.amazon.com/message/2329B7/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- hardware
 company: Amazon
 product: ""
 

--- a/data/db126e26-be84-4286-a778-975bbe87df0d.md
+++ b/data/db126e26-be84-4286-a778-975bbe87df0d.md
@@ -2,6 +2,7 @@
 uuid: db126e26-be84-4286-a778-975bbe87df0d
 url: https://community.eveonline.com/news/dev-blogs/sleeping-beauty/
 categories:
+- cloud
 - postmortem
 company: CCP Games
 product: ""

--- a/data/dc2df2ab-1c9d-4e02-9368-31be29f747bf.md
+++ b/data/dc2df2ab-1c9d-4e02-9368-31be29f747bf.md
@@ -2,6 +2,8 @@
 uuid: dc2df2ab-1c9d-4e02-9368-31be29f747bf
 url: https://github.com/valvesoftware/steam-for-linux/issues/3671
 categories:
+- cloud
+- config-change
 - postmortem
 company: Valve
 product: ""

--- a/data/dca56c0e-0148-416a-bed5-0b43fe7ce3d5.md
+++ b/data/dca56c0e-0148-416a-bed5-0b43fe7ce3d5.md
@@ -2,7 +2,10 @@
 uuid: dca56c0e-0148-416a-bed5-0b43fe7ce3d5
 url: https://www.browserstack.com/attack-and-downtime-on-9-November
 categories:
+- automation
+- cloud
 - postmortem
+- security
 company: BrowserStack
 product: ""
 

--- a/data/df0aad9f-5319-4346-a707-07f90de60b3c.md
+++ b/data/df0aad9f-5319-4346-a707-07f90de60b3c.md
@@ -2,6 +2,7 @@
 uuid: df0aad9f-5319-4346-a707-07f90de60b3c
 url: http://googleblog.blogspot.com/2014/01/todays-outage-for-several-google.html
 categories:
+- cloud
 - postmortem
 company: Google
 product: ""

--- a/data/dfca998b-0d9b-4f99-b03b-6a6d72175421.md
+++ b/data/dfca998b-0d9b-4f99-b03b-6a6d72175421.md
@@ -2,6 +2,8 @@
 uuid: dfca998b-0d9b-4f99-b03b-6a6d72175421
 url: https://en.wikipedia.org/wiki/Cluster_%28spacecraft%29?oldid=217305667
 categories:
+- automation
+- cascading-failure
 - postmortem
 company: European Space Agency
 product: ""

--- a/data/e0a66df6-a56a-4082-9f0e-60755cbb8191.md
+++ b/data/e0a66df6-a56a-4082-9f0e-60755cbb8191.md
@@ -2,6 +2,8 @@
 uuid: e0a66df6-a56a-4082-9f0e-60755cbb8191
 url: https://www.traviscistatus.com/incidents/sxrh0l46czqn
 categories:
+- cloud
+- config-change
 - postmortem
 company: TravisCI
 product: ""

--- a/data/e16b28f3-b6d4-449b-ae93-cc8a4d074163.md
+++ b/data/e16b28f3-b6d4-449b-ae93-cc8a4d074163.md
@@ -2,7 +2,9 @@
 uuid: e16b28f3-b6d4-449b-ae93-cc8a4d074163
 url: https://web.archive.org/web/20211016040522/https://blog.cloudflare.com/cloudflare-outage-on-july-17-2020/
 categories:
+- config-change
 - postmortem
+- security
 company: Cloudflare
 product: ""
 

--- a/data/e5d63957-75ff-4e09-8f1c-df2e77df71b0.md
+++ b/data/e5d63957-75ff-4e09-8f1c-df2e77df71b0.md
@@ -2,6 +2,7 @@
 uuid: e5d63957-75ff-4e09-8f1c-df2e77df71b0
 url: https://mail.tarsnap.com/tarsnap-announce/msg00035.html
 categories:
+- cloud
 - postmortem
 company: Tarsnap
 product: ""

--- a/data/e7d7aa93-81f7-4338-9c0b-6e6c0dcefdcb.md
+++ b/data/e7d7aa93-81f7-4338-9c0b-6e6c0dcefdcb.md
@@ -2,6 +2,7 @@
 uuid: e7d7aa93-81f7-4338-9c0b-6e6c0dcefdcb
 url: http://mail.tarsnap.com/tarsnap-announce/msg00035.html
 categories:
+- cloud
 - postmortem
 company: Tarsnap
 product: ""

--- a/data/e81a4a73-8808-42da-9841-9bd4fcc8b9be.md
+++ b/data/e81a4a73-8808-42da-9841-9bd4fcc8b9be.md
@@ -2,7 +2,12 @@
 uuid: e81a4a73-8808-42da-9841-9bd4fcc8b9be
 url: https://blog.cloudflare.com/cloudflare-incident-on-january-24th-2023/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- hardware
+- security
 company: Cloudflare
 product: ""
 

--- a/data/e9563dd5-d6a6-4798-b127-d32e1608f6de.md
+++ b/data/e9563dd5-d6a6-4798-b127-d32e1608f6de.md
@@ -2,7 +2,11 @@
 uuid: e9563dd5-d6a6-4798-b127-d32e1608f6de
 url: https://blog.cloudflare.com/how-and-why-the-leap-second-affected-cloudflare-dns/
 categories:
+- automation
+- cascading-failure
+- config-change
 - postmortem
+- time
 company: Cloudflare
 product: ""
 

--- a/data/ef3cc3e0-c51c-4f5d-8dd0-cc8a8dfdcbb2.md
+++ b/data/ef3cc3e0-c51c-4f5d-8dd0-cc8a8dfdcbb2.md
@@ -2,6 +2,9 @@
 uuid: ef3cc3e0-c51c-4f5d-8dd0-cc8a8dfdcbb2
 url: https://dougseven.com/2014/04/17/knightmare-a-devops-cautionary-tale/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Knight Capital
 product: ""

--- a/data/f4458caf-d848-419a-966e-07c9020cfc48.md
+++ b/data/f4458caf-d848-419a-966e-07c9020cfc48.md
@@ -2,6 +2,9 @@
 uuid: f4458caf-d848-419a-966e-07c9020cfc48
 url: https://azure.microsoft.com/en-us/blog/update-on-azure-storage-service-interruption/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Microsoft
 product: ""

--- a/data/f4d13c23-5dca-4deb-8ddb-c4bdfc4fea4c.md
+++ b/data/f4d13c23-5dca-4deb-8ddb-c4bdfc4fea4c.md
@@ -2,7 +2,9 @@
 uuid: f4d13c23-5dca-4deb-8ddb-c4bdfc4fea4c
 url: https://web.archive.org/web/20220427012208/https://lkml.org/lkml/2009/1/2/373
 categories:
+- cloud
 - postmortem
+- time
 company: Linux
 product: ""
 

--- a/data/f4db61bf-cdd6-4dff-9777-5185c3f5e24b.md
+++ b/data/f4db61bf-cdd6-4dff-9777-5185c3f5e24b.md
@@ -2,7 +2,11 @@
 uuid: f4db61bf-cdd6-4dff-9777-5185c3f5e24b
 url: https://aws.amazon.com/message/67457/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- hardware
 company: Amazon
 product: ""
 

--- a/data/f70ce67c-0944-422e-b0bd-be38f0edb0cd.md
+++ b/data/f70ce67c-0944-422e-b0bd-be38f0edb0cd.md
@@ -2,7 +2,11 @@
 uuid: f70ce67c-0944-422e-b0bd-be38f0edb0cd
 url: https://about.gitlab.com/2017/02/10/postmortem-of-database-outage-of-january-31/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
+- hardware
 company: Gitlab
 product: ""
 

--- a/data/f824c623-7f26-4bf7-9c02-7c39475af100.md
+++ b/data/f824c623-7f26-4bf7-9c02-7c39475af100.md
@@ -2,6 +2,8 @@
 uuid: f824c623-7f26-4bf7-9c02-7c39475af100
 url: https://gist.github.com/jomo/2bae3821acb433d0446d
 categories:
+- automation
+- cloud
 - postmortem
 company: Google
 product: ""

--- a/data/f89b8bcd-6742-4fd9-b8ab-c1c6e21691ec.md
+++ b/data/f89b8bcd-6742-4fd9-b8ab-c1c6e21691ec.md
@@ -1,12 +1,11 @@
 ---
-
-uuid: "f89b8bcd-6742-4fd9-b8ab-c1c6e21691ec"
-url: "https://plus.google.com/+AndreasSchou/posts/FhWtABz7ew9"
-start_time: ""
-end_time: ""
+uuid: f89b8bcd-6742-4fd9-b8ab-c1c6e21691ec
+url: https://plus.google.com/+AndreasSchou/posts/FhWtABz7ew9
 categories:
+- automation
+- cloud
 - postmortem
-company: "Healthcare.gov"
+company: Healthcare.gov
 product: ""
 
 ---

--- a/data/fde04641-ac3a-499a-887e-fb5d26184c09.md
+++ b/data/fde04641-ac3a-499a-887e-fb5d26184c09.md
@@ -2,6 +2,9 @@
 uuid: fde04641-ac3a-499a-887e-fb5d26184c09
 url: https://aws.amazon.com/message/41926/
 categories:
+- automation
+- cloud
+- config-change
 - postmortem
 company: Amazon
 product: ""

--- a/tool/categorize.go
+++ b/tool/categorize.go
@@ -1,0 +1,321 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/icco/postmortems"
+)
+
+// categoryPatterns maps a category name in postmortems.Categories to a
+// set of case-insensitive regular expressions. If any pattern matches
+// the body of a postmortem's source URL the category is suggested.
+//
+// We deliberately omit "postmortem" (every entry already has it) and
+// "undescriptive" (a subjective judgement that should not be
+// auto-applied).
+var categoryPatterns = map[string][]*regexp.Regexp{
+	"automation": {
+		mustRegex(`\bautomation\b`),
+		mustRegex(`\bautomated\b`),
+		mustRegex(`\bauto[- ]?scaling\b`),
+	},
+	"cascading-failure": {
+		mustRegex(`\bcascad(e|ing)\b`),
+		mustRegex(`\bdomino\b`),
+		mustRegex(`\bthundering herd\b`),
+	},
+	"cloud": {
+		mustRegex(`\baws\b`),
+		mustRegex(`\bamazon web services\b`),
+		mustRegex(`\bgcp\b`),
+		mustRegex(`\bgoogle cloud\b`),
+		mustRegex(`\bazure\b`),
+		mustRegex(`\bec2\b`),
+		mustRegex(`\bs3\b`),
+		mustRegex(`\bkubernetes\b`),
+		mustRegex(`\bcloud provider\b`),
+	},
+	"config-change": {
+		mustRegex(`\bconfig(uration)? change\b`),
+		mustRegex(`\bbad config\b`),
+		mustRegex(`\bmisconfigur(ation|ed)\b`),
+		mustRegex(`\bdeploy(ment)?\b`),
+		mustRegex(`\brollout\b`),
+	},
+	"hardware": {
+		mustRegex(`\bhardware (failure|fault|issue)\b`),
+		mustRegex(`\bdisk (failure|fault|fail)\b`),
+		mustRegex(`\bssd (failure|fault)\b`),
+		mustRegex(`\bnetwork card\b`),
+		mustRegex(`\brouter (failure|fault)\b`),
+		mustRegex(`\bpower (failure|outage|loss)\b`),
+		mustRegex(`\bdata ?cent(re|er) (failure|outage)\b`),
+	},
+	"security": {
+		mustRegex(`\bsecurity (incident|breach|advisory)\b`),
+		mustRegex(`\bvulnerab(le|ility)\b`),
+		mustRegex(`\bexploit(ed|ation)?\b`),
+		mustRegex(`\bbreach\b`),
+		mustRegex(`\bleaked? credential\b`),
+		mustRegex(`\bcve-\d{4}-\d+`),
+	},
+	"time": {
+		mustRegex(`\bntp\b`),
+		mustRegex(`\btimezone\b`),
+		mustRegex(`\bleap second\b`),
+		mustRegex(`\bdaylight saving\b`),
+		mustRegex(`\bclock skew\b`),
+	},
+}
+
+func mustRegex(p string) *regexp.Regexp {
+	return regexp.MustCompile(`(?i)` + p)
+}
+
+// categorizeOptions configures the categorize action.
+type categorizeOptions struct {
+	Dir         string
+	Apply       bool
+	HTTPTimeout time.Duration
+	Concurrency int
+}
+
+// categorizeResult is one tool report row.
+type categorizeResult struct {
+	Path        string
+	URL         string
+	Existing    []string
+	Suggestions []string
+	Err         error
+	StatusCode  int
+}
+
+// CategorizePostmortems scrapes every postmortem source URL under dir,
+// matches the body against categoryPatterns, and reports (or applies)
+// suggested categories. It returns the per-file results so callers
+// can render their own summaries; errors fetching individual URLs are
+// reported on the result struct rather than aborting the whole run.
+func CategorizePostmortems(opts categorizeOptions) ([]categorizeResult, error) {
+	if opts.Dir == "" {
+		return nil, fmt.Errorf("dir is required")
+	}
+	if opts.HTTPTimeout == 0 {
+		opts.HTTPTimeout = 15 * time.Second
+	}
+	if opts.Concurrency <= 0 {
+		opts.Concurrency = 8
+	}
+
+	files, err := os.ReadDir(opts.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir: %w", err)
+	}
+
+	type job struct {
+		path string
+	}
+	jobs := make(chan job)
+	results := make(chan categorizeResult)
+
+	client := &http.Client{Timeout: opts.HTTPTimeout}
+
+	var wg sync.WaitGroup
+	for i := 0; i < opts.Concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobs {
+				results <- processFile(client, j.path, opts.Apply)
+			}
+		}()
+	}
+
+	go func() {
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+			jobs <- job{path: filepath.Join(opts.Dir, f.Name())}
+		}
+		close(jobs)
+		wg.Wait()
+		close(results)
+	}()
+
+	var out []categorizeResult
+	for r := range results {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out, nil
+}
+
+// processFile fetches one postmortem's source URL, matches the body
+// against categoryPatterns, and (when apply is true) merges the
+// suggested categories back into the markdown file.
+func processFile(client *http.Client, path string, apply bool) categorizeResult {
+	res := categorizeResult{Path: path}
+	f, err := os.Open(path) // #nosec G304 -- iterated path under the configured data dir
+	if err != nil {
+		res.Err = err
+		return res
+	}
+	pm, err := postmortems.Parse(f)
+	closeErr := f.Close()
+	if err != nil {
+		res.Err = err
+		return res
+	}
+	if closeErr != nil {
+		res.Err = closeErr
+		return res
+	}
+
+	res.URL = pm.URL
+	res.Existing = append(res.Existing, pm.Categories...)
+
+	if pm.URL == "" {
+		res.Err = fmt.Errorf("empty url")
+		return res
+	}
+
+	body, status, err := fetchBody(client, pm.URL)
+	res.StatusCode = status
+	if err != nil {
+		res.Err = err
+		return res
+	}
+
+	res.Suggestions = matchCategories(body, pm.Categories)
+	if !apply || len(res.Suggestions) == 0 {
+		return res
+	}
+
+	merged := mergeCategories(pm.Categories, res.Suggestions)
+	pm.Categories = merged
+	dir := filepath.Dir(path)
+	if err := pm.Save(dir); err != nil {
+		res.Err = fmt.Errorf("save: %w", err)
+	}
+	return res
+}
+
+func fetchBody(client *http.Client, u string) (string, int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), client.Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return "", 0, err
+	}
+	req.Header.Set("User-Agent", "icco-postmortems-categorizer/1.0 (+https://postmortems.app)")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", resp.StatusCode, fmt.Errorf("http %d", resp.StatusCode)
+	}
+
+	const maxRead = 4 * 1024 * 1024 // 4 MiB cap, sufficient for a long blog post.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxRead))
+	if err != nil {
+		return "", resp.StatusCode, err
+	}
+	return string(data), resp.StatusCode, nil
+}
+
+// matchCategories returns the categories whose patterns match the body
+// and that are not already in existing.
+func matchCategories(body string, existing []string) []string {
+	have := map[string]bool{}
+	for _, c := range existing {
+		have[c] = true
+	}
+
+	var out []string
+	for _, cat := range postmortems.Categories {
+		patterns, ok := categoryPatterns[cat]
+		if !ok {
+			continue
+		}
+		if have[cat] {
+			continue
+		}
+		for _, p := range patterns {
+			if p.MatchString(body) {
+				out = append(out, cat)
+				break
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// mergeCategories returns the union of existing and suggestions in a
+// deterministic order driven by postmortems.Categories.
+func mergeCategories(existing, suggestions []string) []string {
+	have := map[string]bool{}
+	for _, c := range existing {
+		have[c] = true
+	}
+	for _, c := range suggestions {
+		have[c] = true
+	}
+	var out []string
+	for _, c := range postmortems.Categories {
+		if have[c] {
+			out = append(out, c)
+		}
+	}
+	for _, c := range existing {
+		if !contains(out, c) {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// printCategorizeReport writes a human-readable summary of res to w.
+func printCategorizeReport(w io.Writer, res []categorizeResult, apply bool) {
+	var changed, fetchErrs, total int
+	for _, r := range res {
+		total++
+		if r.Err != nil {
+			fetchErrs++
+			fmt.Fprintf(w, "ERR  %s (%s): %v\n", filepath.Base(r.Path), r.URL, r.Err)
+			continue
+		}
+		if len(r.Suggestions) == 0 {
+			continue
+		}
+		changed++
+		marker := "SUGGEST"
+		if apply {
+			marker = "APPLIED"
+		}
+		fmt.Fprintf(w, "%s %s -> %v\n", marker, filepath.Base(r.Path), r.Suggestions)
+	}
+	fmt.Fprintf(w, "\nprocessed=%d  with-suggestions=%d  fetch-errors=%d\n", total, changed, fetchErrs)
+}

--- a/tool/categorize.go
+++ b/tool/categorize.go
@@ -15,6 +15,19 @@ import (
 	"github.com/icco/postmortems"
 )
 
+// Category names used by both the matcher map and tests. Mirrors the
+// strings in postmortems.Categories.
+const (
+	catAutomation       = "automation"
+	catCascadingFailure = "cascading-failure"
+	catCloud            = "cloud"
+	catConfigChange     = "config-change"
+	catHardware         = "hardware"
+	catSecurity         = "security"
+	catTime             = "time"
+	catPostmortem       = "postmortem"
+)
+
 // categoryPatterns maps a category name in postmortems.Categories to a
 // set of case-insensitive regular expressions. If any pattern matches
 // the body of a postmortem's source URL the category is suggested.
@@ -23,17 +36,17 @@ import (
 // "undescriptive" (a subjective judgement that should not be
 // auto-applied).
 var categoryPatterns = map[string][]*regexp.Regexp{
-	"automation": {
+	catAutomation: {
 		mustRegex(`\bautomation\b`),
 		mustRegex(`\bautomated\b`),
 		mustRegex(`\bauto[- ]?scaling\b`),
 	},
-	"cascading-failure": {
+	catCascadingFailure: {
 		mustRegex(`\bcascad(e|ing)\b`),
 		mustRegex(`\bdomino\b`),
 		mustRegex(`\bthundering herd\b`),
 	},
-	"cloud": {
+	catCloud: {
 		mustRegex(`\baws\b`),
 		mustRegex(`\bamazon web services\b`),
 		mustRegex(`\bgcp\b`),
@@ -44,14 +57,14 @@ var categoryPatterns = map[string][]*regexp.Regexp{
 		mustRegex(`\bkubernetes\b`),
 		mustRegex(`\bcloud provider\b`),
 	},
-	"config-change": {
+	catConfigChange: {
 		mustRegex(`\bconfig(uration)? change\b`),
 		mustRegex(`\bbad config\b`),
 		mustRegex(`\bmisconfigur(ation|ed)\b`),
 		mustRegex(`\bdeploy(ment)?\b`),
 		mustRegex(`\brollout\b`),
 	},
-	"hardware": {
+	catHardware: {
 		mustRegex(`\bhardware (failure|fault|issue)\b`),
 		mustRegex(`\bdisk (failure|fault|fail)\b`),
 		mustRegex(`\bssd (failure|fault)\b`),
@@ -60,7 +73,7 @@ var categoryPatterns = map[string][]*regexp.Regexp{
 		mustRegex(`\bpower (failure|outage|loss)\b`),
 		mustRegex(`\bdata ?cent(re|er) (failure|outage)\b`),
 	},
-	"security": {
+	catSecurity: {
 		mustRegex(`\bsecurity (incident|breach|advisory)\b`),
 		mustRegex(`\bvulnerab(le|ility)\b`),
 		mustRegex(`\bexploit(ed|ation)?\b`),
@@ -68,7 +81,7 @@ var categoryPatterns = map[string][]*regexp.Regexp{
 		mustRegex(`\bleaked? credential\b`),
 		mustRegex(`\bcve-\d{4}-\d+`),
 	},
-	"time": {
+	catTime: {
 		mustRegex(`\bntp\b`),
 		mustRegex(`\btimezone\b`),
 		mustRegex(`\bleap second\b`),
@@ -298,13 +311,15 @@ func contains(s []string, v string) bool {
 }
 
 // printCategorizeReport writes a human-readable summary of res to w.
+// Write errors on a CLI report writer are not actionable, so they are
+// intentionally ignored.
 func printCategorizeReport(w io.Writer, res []categorizeResult, apply bool) {
 	var changed, fetchErrs, total int
 	for _, r := range res {
 		total++
 		if r.Err != nil {
 			fetchErrs++
-			fmt.Fprintf(w, "ERR  %s (%s): %v\n", filepath.Base(r.Path), r.URL, r.Err)
+			_, _ = fmt.Fprintf(w, "ERR  %s (%s): %v\n", filepath.Base(r.Path), r.URL, r.Err)
 			continue
 		}
 		if len(r.Suggestions) == 0 {
@@ -315,7 +330,7 @@ func printCategorizeReport(w io.Writer, res []categorizeResult, apply bool) {
 		if apply {
 			marker = "APPLIED"
 		}
-		fmt.Fprintf(w, "%s %s -> %v\n", marker, filepath.Base(r.Path), r.Suggestions)
+		_, _ = fmt.Fprintf(w, "%s %s -> %v\n", marker, filepath.Base(r.Path), r.Suggestions)
 	}
-	fmt.Fprintf(w, "\nprocessed=%d  with-suggestions=%d  fetch-errors=%d\n", total, changed, fetchErrs)
+	_, _ = fmt.Fprintf(w, "\nprocessed=%d  with-suggestions=%d  fetch-errors=%d\n", total, changed, fetchErrs)
 }

--- a/tool/categorize_test.go
+++ b/tool/categorize_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMatchCategories(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		existing []string
+		want     []string
+	}{
+		{
+			name:     "cloud and config",
+			body:     "We rolled out a bad config to our AWS EC2 fleet.",
+			existing: []string{"postmortem"},
+			want:     []string{"cloud", "config-change"},
+		},
+		{
+			name:     "skip already-present categories",
+			body:     "Cascading failure across the cluster after a misconfiguration.",
+			existing: []string{"postmortem", "cascading-failure"},
+			want:     []string{"config-change"},
+		},
+		{
+			name:     "no matches",
+			body:     "Nothing in this body should trigger anything.",
+			existing: []string{"postmortem"},
+			want:     nil,
+		},
+		{
+			name:     "ntp triggers time",
+			body:     "An NTP misconfiguration confused our log timestamps.",
+			existing: []string{"postmortem"},
+			want:     []string{"config-change", "time"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := matchCategories(tc.body, tc.existing)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("matchCategories() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMergeCategories(t *testing.T) {
+	// Order is the declaration order in postmortems.Categories.
+	got := mergeCategories([]string{"postmortem"}, []string{"cloud", "config-change"})
+	want := []string{"cloud", "config-change", "postmortem"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("mergeCategories() = %v, want %v", got, want)
+	}
+
+	got = mergeCategories([]string{"postmortem", "hardware"}, []string{"hardware", "cloud"})
+	want = []string{"cloud", "postmortem", "hardware"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("mergeCategories() with overlap = %v, want %v", got, want)
+	}
+}

--- a/tool/categorize_test.go
+++ b/tool/categorize_test.go
@@ -15,26 +15,26 @@ func TestMatchCategories(t *testing.T) {
 		{
 			name:     "cloud and config",
 			body:     "We rolled out a bad config to our AWS EC2 fleet.",
-			existing: []string{"postmortem"},
-			want:     []string{"cloud", "config-change"},
+			existing: []string{catPostmortem},
+			want:     []string{catCloud, catConfigChange},
 		},
 		{
 			name:     "skip already-present categories",
 			body:     "Cascading failure across the cluster after a misconfiguration.",
-			existing: []string{"postmortem", "cascading-failure"},
-			want:     []string{"config-change"},
+			existing: []string{catPostmortem, catCascadingFailure},
+			want:     []string{catConfigChange},
 		},
 		{
 			name:     "no matches",
 			body:     "Nothing in this body should trigger anything.",
-			existing: []string{"postmortem"},
+			existing: []string{catPostmortem},
 			want:     nil,
 		},
 		{
 			name:     "ntp triggers time",
 			body:     "An NTP misconfiguration confused our log timestamps.",
-			existing: []string{"postmortem"},
-			want:     []string{"config-change", "time"},
+			existing: []string{catPostmortem},
+			want:     []string{catConfigChange, catTime},
 		},
 	}
 
@@ -52,14 +52,14 @@ func TestMatchCategories(t *testing.T) {
 
 func TestMergeCategories(t *testing.T) {
 	// Order is the declaration order in postmortems.Categories.
-	got := mergeCategories([]string{"postmortem"}, []string{"cloud", "config-change"})
-	want := []string{"cloud", "config-change", "postmortem"}
+	got := mergeCategories([]string{catPostmortem}, []string{catCloud, catConfigChange})
+	want := []string{catCloud, catConfigChange, catPostmortem}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("mergeCategories() = %v, want %v", got, want)
 	}
 
-	got = mergeCategories([]string{"postmortem", "hardware"}, []string{"hardware", "cloud"})
-	want = []string{"cloud", "postmortem", "hardware"}
+	got = mergeCategories([]string{catPostmortem, catHardware}, []string{catHardware, catCloud})
+	want = []string{catCloud, catPostmortem, catHardware}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("mergeCategories() with overlap = %v, want %v", got, want)
 	}

--- a/tool/main.go
+++ b/tool/main.go
@@ -25,9 +25,12 @@ import (
 )
 
 var (
-	log    = logging.Must(logging.NewLogger(postmortems.Service))
-	action = flag.String("action", "", "")
-	dir    = flag.String("dir", "./data/", "")
+	log              = logging.Must(logging.NewLogger(postmortems.Service))
+	action           = flag.String("action", "", "")
+	dir              = flag.String("dir", "./data/", "")
+	categorizeApply  = flag.Bool("apply", false, "categorize: write suggested categories back into the markdown files (default: dry run)")
+	categorizeWorker = flag.Int("workers", 8, "categorize: number of concurrent HTTP fetchers")
+	categorizeTime   = flag.Duration("http-timeout", 15*time.Second, "categorize: per-URL fetch timeout")
 	qs     = []*survey.Question{
 		{
 			Name:     "url",
@@ -74,6 +77,8 @@ generate        Generate JSON files from the postmortem Markdown files.
 new             Create a new postmortem file.
 validate        Validate the postmortem files in the directory.
 serve           Serve the postmortem files in a small website.
+categorize      Scrape each postmortem URL and suggest additional categories.
+                Pass -apply to write suggestions back to the markdown files.
 `
 	danluuReadme = "https://raw.githubusercontent.com/danluu/post-mortems/master/README.md"
 	extractFile  = "./tmp/posts.md"
@@ -152,6 +157,17 @@ func main() {
 		err = newPostmortem(*dir)
 	case "validate":
 		_, err = postmortems.ValidateDir(*dir)
+	case "categorize":
+		var res []categorizeResult
+		res, err = CategorizePostmortems(categorizeOptions{
+			Dir:         *dir,
+			Apply:       *categorizeApply,
+			HTTPTimeout: *categorizeTime,
+			Concurrency: *categorizeWorker,
+		})
+		if err == nil {
+			printCategorizeReport(os.Stdout, res, *categorizeApply)
+		}
 	case "serve":
 		err = Serve()
 	default:

--- a/tool/main.go
+++ b/tool/main.go
@@ -57,7 +57,7 @@ var (
 			Prompt: &survey.MultiSelect{
 				Message:  "Select categories:",
 				Options:  postmortems.Categories,
-				Default:  "postmortem",
+				Default:  catPostmortem,
 				PageSize: len(postmortems.Categories),
 			},
 		},


### PR DESCRIPTION
## Summary

- Adds a one-shot "categorize" action to ./tool that fetches each postmortem's source URL, greps the response body against case-insensitive regular expressions per category (see tool/categorize.go), and either prints suggestions (default dry-run) or merges them into the markdown frontmatter (-apply).
- Adds the result of running it once: 243 entries processed, 150 received at least one new category, 49 fetch errors (404, 403, expired TLS, etc.) were left unchanged.
- Updates README with the dry-run / -apply usage and the explicit "review before merge" expectation.

The applied categories are suggestions only -- the diff is intended to be reviewed by a human, not merged blind. There is no automated PR-filing bot. Reviewers should feel free to drop any of the data/*.md hunks that look noisy and merge the rest.

## Test Plan

- [x] go build ./...
- [x] go test ./... (new TestMatchCategories, TestMergeCategories)
- [x] go run ./tool -action=validate -dir=./data succeeds against the corpus after applying suggestions

Fixes #31