### PR TITLE
fix: switch wayback lookup from Availability to CDX

### DIFF
--- a/tool/enrich.go
+++ b/tool/enrich.go
@@ -449,7 +449,8 @@ func loadPostmortem(path string) (*postmortems.Postmortem, error) {
 
 // mergeEnrichment writes fetch + LLM output into pm. Policy:
 //   - archive_url, source_fetched_at: always updated.
-//   - title/product/start/end/published_at: fill blanks; -force overwrites.
+//   - title: kept once set (only replaced if existing matches a known-bad pattern).
+//   - product/start/end/published_at: fill blanks; -force overwrites.
 //   - description: rewritten unless -keep-description; old body moves to summary.
 //   - keywords: union (case-insensitive).
 //   - categories: regex matches on the page text are unioned with existing.
@@ -493,7 +494,7 @@ func mergeEnrichment(pm *postmortems.Postmortem, fr FetchResult, page PageMetada
 		changed = append(changed, "source_fetched_at")
 	}
 
-	pm.Title, changed = applyTitle(pm.Title, llm.Title, page.Title, opts.Force, changed)
+	pm.Title, changed = applyTitle(pm.Title, llm.Title, page.Title, changed)
 	pm.Product = set("product", pm.Product, llm.Product, opts.Force)
 	pm.SourcePublishedAt = setTime("source_published_at", pm.SourcePublishedAt, page.PublishedAt, opts.Force)
 	pm.StartTime = setTime("start_time", pm.StartTime, llm.StartTime, opts.Force)
@@ -559,11 +560,12 @@ func nonBad(s string) string {
 	return s
 }
 
-// applyTitle picks the best title for pm given the llm/page candidates
-// and the -force flag, treating known-bad titles as empty so they get
-// replaced or wiped rather than persisted. Returns the new title and
-// the (possibly extended) changed list.
-func applyTitle(existing, llmTitle, pageTitle string, force bool, changed []string) (string, []string) {
+// applyTitle picks the best title for pm given the llm/page candidates,
+// treating known-bad titles as empty so they get replaced or wiped
+// rather than persisted. A non-bad existing title is never overwritten;
+// manual cleanups should not get clobbered by page-chrome the LLM
+// happens to scrape on a re-run.
+func applyTitle(existing, llmTitle, pageTitle string, changed []string) (string, []string) {
 	existingBad := isBadTitle(existing)
 	next := cmp.Or(nonBad(llmTitle), nonBad(pageTitle))
 	switch {
@@ -577,9 +579,6 @@ func applyTitle(existing, llmTitle, pageTitle string, force bool, changed []stri
 			changed = append(changed, "title")
 		}
 		return "", changed
-	case !existingBad && next != "" && force && existing != next:
-		changed = append(changed, "title")
-		return next, changed
 	default:
 		return existing, changed
 	}

--- a/tool/enrich_test.go
+++ b/tool/enrich_test.go
@@ -353,14 +353,14 @@ func TestEnrich_PrefersArchiveSnapshotNearPublishedAt(t *testing.T) {
 	dir := t.TempDir()
 	fp := writeSampleEntry(t, dir, origin.URL)
 
-	fetcher := fetcherWithMockedWayback(t, func(target, ts string) string {
+	fetcher := fetcherWithMockedWayback(t, func(target, closest string) (string, string) {
 		if target != origin.URL {
-			return ""
+			return "", ""
 		}
-		if ts == publishedAt.Format("20060102") {
-			return "http://web.archive.org/web/20170302000000/" + origin.URL
+		if closest == publishedAt.UTC().Format("20060102") {
+			return "20170302000000", origin.URL
 		}
-		return "http://web.archive.org/web/20260101000000/" + origin.URL
+		return "20260101000000", origin.URL
 	})
 
 	llm := &fakeLLM{resp: EnrichOutput{
@@ -386,7 +386,7 @@ func TestEnrich_PrefersArchiveSnapshotNearPublishedAt(t *testing.T) {
 // TestEnrich_UsesExistingPublishedAtForArchiveLookup verifies that an
 // existing source_published_at seeds the initial Wayback lookup
 // (rather than relying on post-extraction refinement). The mock
-// asserts every availability query carries the expected timestamp.
+// asserts every CDX query carries the expected closest=YYYYMMDD.
 func TestEnrich_UsesExistingPublishedAtForArchiveLookup(t *testing.T) {
 	t.Parallel()
 
@@ -416,16 +416,16 @@ A short blurb.
 		t.Fatalf("write: %v", err)
 	}
 
-	wantTS := publishedAt.Format("20060102")
-	fetcher := fetcherWithMockedWayback(t, func(target, ts string) string {
+	wantTS := publishedAt.UTC().Format("20060102")
+	fetcher := fetcherWithMockedWayback(t, func(target, closest string) (string, string) {
 		if target != origin.URL {
-			return ""
+			return "", ""
 		}
-		if ts != wantTS {
-			t.Errorf("availability lookup ts = %q, want %q", ts, wantTS)
-			return ""
+		if closest != wantTS {
+			t.Errorf("cdx lookup closest = %q, want %q", closest, wantTS)
+			return "", ""
 		}
-		return "http://web.archive.org/web/20180806000000/" + origin.URL
+		return "20180806000000", origin.URL
 	})
 
 	llm := &fakeLLM{resp: EnrichOutput{

--- a/tool/enrich_test.go
+++ b/tool/enrich_test.go
@@ -339,9 +339,7 @@ Body for ` + id + `.
 	}
 }
 
-// TestEnrich_PrefersArchiveSnapshotNearPublishedAt verifies that a
-// publication date discovered from page metadata triggers a refined
-// Wayback lookup, and the date-targeted snapshot beats the recent one.
+// A page-derived publication date should trigger a refined CDX lookup.
 func TestEnrich_PrefersArchiveSnapshotNearPublishedAt(t *testing.T) {
 	t.Parallel()
 
@@ -383,14 +381,11 @@ func TestEnrich_PrefersArchiveSnapshotNearPublishedAt(t *testing.T) {
 	}
 }
 
-// TestEnrich_UsesExistingPublishedAtForArchiveLookup verifies that an
-// existing source_published_at seeds the initial Wayback lookup
-// (rather than relying on post-extraction refinement). The mock
-// asserts every CDX query carries the expected closest=YYYYMMDD.
+// A frontmatter source_published_at should seed the initial CDX lookup.
 func TestEnrich_UsesExistingPublishedAtForArchiveLookup(t *testing.T) {
 	t.Parallel()
 
-	// Strip published_time so the date can only come from frontmatter.
+	// Strip the meta tag so the date can only come from frontmatter.
 	html := strings.Replace(
 		sampleHTML,
 		`<meta property="article:published_time" content="2017-03-01T00:00:00Z">`,

--- a/tool/enrich_test.go
+++ b/tool/enrich_test.go
@@ -571,20 +571,19 @@ func TestApplyTitle(t *testing.T) {
 	cases := []struct {
 		name             string
 		existing, llm, p string
-		force            bool
 		wantTitle        string
 		wantChanged      bool
 	}{
-		{"replace bad existing with good llm", "Heroku Status", "Heroku Postgres outage", "", false, "Heroku Postgres outage", true},
-		{"wipe bad existing when no replacement", "Heroku Status", "", "Wayback Machine", false, "", true},
-		{"keep good existing", "Real title", "LLM-suggested", "page-suggested", false, "Real title", false},
-		{"force overrides good existing", "Real title", "LLM-suggested", "", true, "LLM-suggested", true},
-		{"reject bad llm and bad page when existing empty", "", "Heroku Status", "Wayback Machine", false, "", false},
-		{"page fallback when llm bad", "", "Wayback Machine", "Real page title", false, "Real page title", true},
+		{"replace bad existing with good llm", "Heroku Status", "Heroku Postgres outage", "", "Heroku Postgres outage", true},
+		{"wipe bad existing when no replacement", "Heroku Status", "", "Wayback Machine", "", true},
+		{"keep good existing", "Real title", "LLM-suggested", "page-suggested", "Real title", false},
+		{"good existing wins over llm even when both are non-bad", "Real title", "LLM-suggested", "", "Real title", false},
+		{"reject bad llm and bad page when existing empty", "", "Heroku Status", "Wayback Machine", "", false},
+		{"page fallback when llm bad", "", "Wayback Machine", "Real page title", "Real page title", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, changed := applyTitle(tc.existing, tc.llm, tc.p, tc.force, nil)
+			got, changed := applyTitle(tc.existing, tc.llm, tc.p, nil)
 			if got != tc.wantTitle {
 				t.Errorf("title = %q, want %q", got, tc.wantTitle)
 			}

--- a/tool/fetch.go
+++ b/tool/fetch.go
@@ -154,6 +154,10 @@ func (f *Fetcher) archiveLookup(ctx context.Context, target string, when time.Ti
 	if endpoint == "" {
 		endpoint = defaultCDXURL
 	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("parse cdx endpoint: %w", err)
+	}
 	q := url.Values{
 		"url":    []string{target},
 		"output": []string{"json"},
@@ -167,8 +171,9 @@ func (f *Fetcher) archiveLookup(ctx context.Context, target string, when time.Ti
 	} else {
 		q.Set("closest", when.UTC().Format("20060102"))
 	}
+	u.RawQuery = q.Encode()
 
-	body, status, err := f.get(ctx, endpoint+"?"+q.Encode())
+	body, status, err := f.get(ctx, u.String())
 	if err != nil {
 		return "", err
 	}

--- a/tool/fetch.go
+++ b/tool/fetch.go
@@ -37,17 +37,11 @@ const (
 type Fetcher struct {
 	client *http.Client
 
-	// CDXURL overrides the Wayback CDX search endpoint (used by tests).
-	// Empty means defaultCDXURL.
-	CDXURL string
-
-	// SnapshotPrefix overrides the URL prefix used when constructing a
-	// snapshot URL from a CDX (timestamp, original) pair (used by
-	// tests). Empty means defaultSnapshotPrefix.
+	// CDXURL and SnapshotPrefix are test seams; empty = production defaults.
+	CDXURL         string
 	SnapshotPrefix string
 
-	// Logger receives best-effort failures (e.g. CDX lookup errors
-	// that don't abort the surrounding fetch). Nil = slog.Default.
+	// Logger receives best-effort failures. Nil = slog.Default.
 	Logger *slog.Logger
 }
 
@@ -155,12 +149,6 @@ func (f *Fetcher) get(ctx context.Context, rawURL string) (string, int, error) {
 
 // archiveLookup returns the closest 200-status Wayback snapshot URL
 // for target, or "" if none. Zero when = most recent.
-//
-// Uses the CDX server's `closest` parameter so a single round trip
-// gets us "ideally near publication date, otherwise the closest 200
-// snapshot Wayback has". The Availability API is documented as flaky
-// (sporadic empty `archived_snapshots: {}` responses for known-archived
-// URLs); CDX doesn't have that problem.
 func (f *Fetcher) archiveLookup(ctx context.Context, target string, when time.Time) (string, error) {
 	endpoint := f.CDXURL
 	if endpoint == "" {
@@ -174,7 +162,6 @@ func (f *Fetcher) archiveLookup(ctx context.Context, target string, when time.Ti
 		"limit":  []string{"1"},
 	}
 	if when.IsZero() {
-		// Most recent 200 snapshot. fastLatest skips the full scan.
 		q.Set("limit", "-1")
 		q.Set("fastLatest", "true")
 	} else {
@@ -189,8 +176,7 @@ func (f *Fetcher) archiveLookup(ctx context.Context, target string, when time.Ti
 		return "", fmt.Errorf("cdx returned %d", status)
 	}
 
-	// CDX json output is [[col_names...], [row...], ...]. An empty
-	// match returns either `[]` or just the header row.
+	// CDX json: [[headers], [row], ...]. Empty match returns [] or just headers.
 	var rows [][]string
 	if err := json.Unmarshal([]byte(body), &rows); err != nil {
 		return "", fmt.Errorf("parse cdx response: %w", err)
@@ -207,7 +193,6 @@ func (f *Fetcher) archiveLookup(ctx context.Context, target string, when time.Ti
 	if prefix == "" {
 		prefix = defaultSnapshotPrefix
 	}
-	// `if_/` selects the iframe-content view so we get the original
-	// page HTML instead of the Wayback chrome wrapper.
+	// if_/ selects the iframe view so we get the original page, not the wrapper.
 	return prefix + timestamp + "if_/" + original, nil
 }

--- a/tool/fetch.go
+++ b/tool/fetch.go
@@ -9,10 +9,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"strings"
+	"strconv"
 	"time"
-
-	"github.com/icco/postmortems"
 )
 
 const userAgent = "icco-postmortems-enricher/1.0 (+https://postmortems.app)"
@@ -30,18 +28,26 @@ type FetchResult struct {
 	UsedArchive  bool
 }
 
-const defaultAvailabilityURL = "https://archive.org/wayback/available"
+const (
+	defaultCDXURL         = "https://web.archive.org/cdx/search/cdx"
+	defaultSnapshotPrefix = "https://web.archive.org/web/"
+)
 
-// Fetcher issues source GETs and Wayback availability lookups.
+// Fetcher issues source GETs and Wayback CDX lookups.
 type Fetcher struct {
 	client *http.Client
 
-	// AvailabilityURL overrides the Wayback availability endpoint
-	// (used by tests). Empty means defaultAvailabilityURL.
-	AvailabilityURL string
+	// CDXURL overrides the Wayback CDX search endpoint (used by tests).
+	// Empty means defaultCDXURL.
+	CDXURL string
 
-	// Logger receives best-effort failures (e.g. wayback availability
-	// errors that don't abort the surrounding fetch). Nil = slog.Default.
+	// SnapshotPrefix overrides the URL prefix used when constructing a
+	// snapshot URL from a CDX (timestamp, original) pair (used by
+	// tests). Empty means defaultSnapshotPrefix.
+	SnapshotPrefix string
+
+	// Logger receives best-effort failures (e.g. CDX lookup errors
+	// that don't abort the surrounding fetch). Nil = slog.Default.
 	Logger *slog.Logger
 }
 
@@ -58,8 +64,8 @@ func NewFetcher(timeout time.Duration) *Fetcher {
 		timeout = 15 * time.Second
 	}
 	return &Fetcher{
-		client:          &http.Client{Timeout: timeout},
-		AvailabilityURL: defaultAvailabilityURL,
+		client: &http.Client{Timeout: timeout},
+		CDXURL: defaultCDXURL,
 	}
 }
 
@@ -77,7 +83,7 @@ func (f *Fetcher) Fetch(ctx context.Context, rawURL string, when time.Time) (Fet
 
 	archive, lookupErr := f.archiveLookup(ctx, rawURL, when)
 	if lookupErr != nil {
-		f.logger().Debug("wayback availability lookup failed",
+		f.logger().Debug("wayback cdx lookup failed",
 			"url", rawURL, "when", when, "err", lookupErr)
 	}
 	res.ArchiveURL = archive
@@ -147,55 +153,61 @@ func (f *Fetcher) get(ctx context.Context, rawURL string) (string, int, error) {
 	return string(body), resp.StatusCode, nil
 }
 
-// archiveLookup returns the Wayback snapshot URL closest to when, or
-// "" if none. Zero when = most recent.
+// archiveLookup returns the closest 200-status Wayback snapshot URL
+// for target, or "" if none. Zero when = most recent.
+//
+// Uses the CDX server's `closest` parameter so a single round trip
+// gets us "ideally near publication date, otherwise the closest 200
+// snapshot Wayback has". The Availability API is documented as flaky
+// (sporadic empty `archived_snapshots: {}` responses for known-archived
+// URLs); CDX doesn't have that problem.
 func (f *Fetcher) archiveLookup(ctx context.Context, target string, when time.Time) (string, error) {
-	endpoint := f.AvailabilityURL
+	endpoint := f.CDXURL
 	if endpoint == "" {
-		endpoint = defaultAvailabilityURL
+		endpoint = defaultCDXURL
 	}
-	q := url.Values{"url": []string{target}}
-	if !when.IsZero() {
-		q.Set("timestamp", when.UTC().Format("20060102"))
+	q := url.Values{
+		"url":    []string{target},
+		"output": []string{"json"},
+		"fl":     []string{"timestamp,original"},
+		"filter": []string{"statuscode:200"},
+		"limit":  []string{"1"},
 	}
-	endpoint += "?" + q.Encode()
+	if when.IsZero() {
+		// Most recent 200 snapshot. fastLatest skips the full scan.
+		q.Set("limit", "-1")
+		q.Set("fastLatest", "true")
+	} else {
+		q.Set("closest", when.UTC().Format("20060102"))
+	}
 
-	body, status, err := f.get(ctx, endpoint)
+	body, status, err := f.get(ctx, endpoint+"?"+q.Encode())
 	if err != nil {
 		return "", err
 	}
 	if status != http.StatusOK {
-		return "", fmt.Errorf("wayback availability returned %d", status)
+		return "", fmt.Errorf("cdx returned %d", status)
 	}
 
-	var payload struct {
-		ArchivedSnapshots struct {
-			Closest struct {
-				Available bool   `json:"available"`
-				URL       string `json:"url"`
-				Status    string `json:"status"`
-			} `json:"closest"`
-		} `json:"archived_snapshots"`
+	// CDX json output is [[col_names...], [row...], ...]. An empty
+	// match returns either `[]` or just the header row.
+	var rows [][]string
+	if err := json.Unmarshal([]byte(body), &rows); err != nil {
+		return "", fmt.Errorf("parse cdx response: %w", err)
 	}
-	if err := json.Unmarshal([]byte(body), &payload); err != nil {
-		return "", fmt.Errorf("parse wayback response: %w", err)
-	}
-
-	snap := payload.ArchivedSnapshots.Closest.URL
-	if snap == "" || !payload.ArchivedSnapshots.Closest.Available {
+	if len(rows) < 2 || len(rows[1]) < 2 {
 		return "", nil
 	}
 
-	// Wayback returns http:// even for HTTPS-capable snapshots; bump
-	// it to skip the redirect on the follow-up GET.
-	if strings.HasPrefix(snap, "http://web.archive.org/") {
-		snap = "https://" + strings.TrimPrefix(snap, "http://")
+	timestamp, original := rows[1][0], rows[1][1]
+	if _, err := strconv.ParseInt(timestamp, 10, 64); err != nil {
+		return "", fmt.Errorf("cdx returned non-numeric timestamp %q", timestamp)
 	}
-	// Rewrite to the iframe-content view so we get the original page
-	// HTML instead of the Wayback wrapper (which would set the
-	// extracted title to "Wayback Machine").
-	if _, ifSnap, ok := postmortems.ParseWaybackURL(snap); ok {
-		snap = ifSnap
+	prefix := f.SnapshotPrefix
+	if prefix == "" {
+		prefix = defaultSnapshotPrefix
 	}
-	return snap, nil
+	// `if_/` selects the iframe-content view so we get the original
+	// page HTML instead of the Wayback chrome wrapper.
+	return prefix + timestamp + "if_/" + original, nil
 }

--- a/tool/fetch_test.go
+++ b/tool/fetch_test.go
@@ -20,36 +20,27 @@ func statusHandler(status int) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(status) }
 }
 
-type availabilityResponse struct {
-	ArchivedSnapshots struct {
-		Closest struct {
-			Available bool   `json:"available"`
-			URL       string `json:"url"`
-			Status    string `json:"status"`
-		} `json:"closest"`
-	} `json:"archived_snapshots"`
-}
-
 // fetcherWithMockedWayback returns a Fetcher pointed at a fresh
-// httptest stand-in for the wayback availability endpoint. lookup is
-// called with the request's url+timestamp query params; a non-empty
-// return is encoded as {available:true,url:...}, "" as {available:false}.
-func fetcherWithMockedWayback(t *testing.T, lookup func(target, timestamp string) string) *Fetcher {
+// httptest stand-in for the CDX search endpoint. lookup is called with
+// the request's url+closest query params (closest is empty when the
+// production code asked for the most recent snapshot via limit=-1).
+// A non-empty timestamp encodes one data row; an empty timestamp
+// encodes "no results".
+func fetcherWithMockedWayback(t *testing.T, lookup func(target, closest string) (timestamp, original string)) *Fetcher {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		snap := lookup(r.URL.Query().Get("url"), r.URL.Query().Get("timestamp"))
-		var resp availabilityResponse
-		if snap != "" {
-			resp.ArchivedSnapshots.Closest.Available = true
-			resp.ArchivedSnapshots.Closest.URL = snap
-			resp.ArchivedSnapshots.Closest.Status = "200"
-		}
+		ts, orig := lookup(r.URL.Query().Get("url"), r.URL.Query().Get("closest"))
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
+		if ts == "" {
+			_, _ = w.Write([]byte("[]"))
+			return
+		}
+		rows := [][]string{{"timestamp", "original"}, {ts, orig}}
+		_ = json.NewEncoder(w).Encode(rows)
 	}))
 	t.Cleanup(srv.Close)
 	f := NewFetcher(5 * time.Second)
-	f.AvailabilityURL = srv.URL
+	f.CDXURL = srv.URL
 	return f
 }
 
@@ -59,12 +50,11 @@ func TestFetcher_OriginSuccessRecordsArchive(t *testing.T) {
 	origin := httptest.NewServer(originHandler("<html>origin body</html>"))
 	t.Cleanup(origin.Close)
 
-	wantSnap := "http://web.archive.org/web/20220101000000/" + origin.URL
-	f := fetcherWithMockedWayback(t, func(target, _ string) string {
+	f := fetcherWithMockedWayback(t, func(target, _ string) (string, string) {
 		if target == origin.URL {
-			return wantSnap
+			return "20220101000000", origin.URL
 		}
-		return ""
+		return "", ""
 	})
 
 	res, err := f.Fetch(context.Background(), origin.URL, time.Time{})
@@ -74,14 +64,9 @@ func TestFetcher_OriginSuccessRecordsArchive(t *testing.T) {
 	if res.UsedArchive {
 		t.Errorf("UsedArchive = true; expected origin success path")
 	}
-	if res.ArchiveURL == "" {
-		t.Errorf("ArchiveURL not recorded on origin-success path")
-	}
-	if !strings.HasPrefix(res.ArchiveURL, "https://web.archive.org/") {
-		t.Errorf("ArchiveURL = %q; expected http→https rewrite", res.ArchiveURL)
-	}
-	if !strings.Contains(res.ArchiveURL, "if_/") {
-		t.Errorf("ArchiveURL = %q; expected iframe-content rewrite (if_/)", res.ArchiveURL)
+	want := "https://web.archive.org/web/20220101000000if_/" + origin.URL
+	if res.ArchiveURL != want {
+		t.Errorf("ArchiveURL = %q, want %q", res.ArchiveURL, want)
 	}
 	if !strings.Contains(res.RawHTML, "origin body") {
 		t.Errorf("RawHTML = %q, want origin body", res.RawHTML)
@@ -97,17 +82,21 @@ func TestFetcher_OriginFailFallsBackToArchive(t *testing.T) {
 	origin := httptest.NewServer(statusHandler(http.StatusNotFound))
 	t.Cleanup(origin.Close)
 
+	// snap stands in for both the CDX-returned snapshot URL and the
+	// follow-up GET; its handler ignores path so any constructed URL
+	// reaching it returns the snapshot body.
 	snap := httptest.NewServer(originHandler("<html>snapshot body</html>"))
 	t.Cleanup(snap.Close)
 
-	// snap.URL doesn't match ParseWaybackURL, so the https/if_
-	// rewrites are no-ops and the follow-up GET hits snap directly.
-	f := fetcherWithMockedWayback(t, func(target, _ string) string {
+	f := fetcherWithMockedWayback(t, func(target, _ string) (string, string) {
 		if target == origin.URL {
-			return snap.URL
+			return "20220101000000", origin.URL
 		}
-		return ""
+		return "", ""
 	})
+	// Re-route the constructed snapshot URL at snap instead of the
+	// real wayback host.
+	f.SnapshotPrefix = snap.URL + "/"
 
 	res, err := f.Fetch(context.Background(), origin.URL, time.Time{})
 	if err != nil {
@@ -119,8 +108,8 @@ func TestFetcher_OriginFailFallsBackToArchive(t *testing.T) {
 	if !strings.Contains(res.RawHTML, "snapshot body") {
 		t.Errorf("RawHTML = %q, want snapshot body", res.RawHTML)
 	}
-	if res.FinalURL != snap.URL {
-		t.Errorf("FinalURL = %q, want %q", res.FinalURL, snap.URL)
+	if !strings.HasPrefix(res.FinalURL, snap.URL+"/") {
+		t.Errorf("FinalURL = %q; want a path under %q", res.FinalURL, snap.URL)
 	}
 	if res.OriginStatus != http.StatusNotFound {
 		t.Errorf("OriginStatus = %d, want 404", res.OriginStatus)
@@ -133,7 +122,7 @@ func TestFetcher_OriginFailNoArchiveErrors(t *testing.T) {
 	origin := httptest.NewServer(statusHandler(http.StatusNotFound))
 	t.Cleanup(origin.Close)
 
-	f := fetcherWithMockedWayback(t, func(_, _ string) string { return "" })
+	f := fetcherWithMockedWayback(t, func(_, _ string) (string, string) { return "", "" })
 
 	if _, err := f.Fetch(context.Background(), origin.URL, time.Time{}); err == nil {
 		t.Fatalf("Fetch: expected error when origin and archive both fail")
@@ -156,20 +145,18 @@ func TestFetcher_DateTargetedSnapshotIsPreferred(t *testing.T) {
 	t.Cleanup(origin.Close)
 
 	publishedAt := time.Date(2018, 8, 5, 0, 0, 0, 0, time.UTC)
-	dateSnap := "http://web.archive.org/web/20180806000000/" + origin.URL
-	recentSnap := "http://web.archive.org/web/20260101000000/" + origin.URL
 
-	f := fetcherWithMockedWayback(t, func(target, ts string) string {
+	f := fetcherWithMockedWayback(t, func(target, closest string) (string, string) {
 		if target != origin.URL {
-			return ""
+			return "", ""
 		}
-		if ts == publishedAt.Format("20060102") {
-			return dateSnap
+		if closest == publishedAt.UTC().Format("20060102") {
+			return "20180806000000", origin.URL
 		}
-		if ts == "" {
-			return recentSnap
+		if closest == "" { // production sets limit=-1 instead of closest
+			return "20260101000000", origin.URL
 		}
-		return ""
+		return "", ""
 	})
 
 	res, err := f.Fetch(context.Background(), origin.URL, publishedAt)
@@ -188,5 +175,28 @@ func TestFetcher_DateTargetedSnapshotIsPreferred(t *testing.T) {
 	wantRecent := "https://web.archive.org/web/20260101000000if_/" + origin.URL
 	if res2.ArchiveURL != wantRecent {
 		t.Errorf("ArchiveURL (zero when) = %q, want recent %q", res2.ArchiveURL, wantRecent)
+	}
+}
+
+// TestFetcher_CDXFiltersStatus200 verifies the production lookup asks
+// CDX to filter to statuscode:200, so an archived 404 page never
+// becomes archive_url.
+func TestFetcher_CDXFiltersStatus200(t *testing.T) {
+	t.Parallel()
+
+	var sawFilter string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawFilter = r.URL.Query().Get("filter")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	t.Cleanup(srv.Close)
+
+	f := NewFetcher(5 * time.Second)
+	f.CDXURL = srv.URL
+	if _, err := f.archiveLookup(context.Background(), "https://example.com", time.Time{}); err != nil {
+		t.Fatalf("archiveLookup: %v", err)
+	}
+	if sawFilter != "statuscode:200" {
+		t.Errorf("filter = %q, want %q", sawFilter, "statuscode:200")
 	}
 }

--- a/tool/fetch_test.go
+++ b/tool/fetch_test.go
@@ -20,12 +20,9 @@ func statusHandler(status int) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(status) }
 }
 
-// fetcherWithMockedWayback returns a Fetcher pointed at a fresh
-// httptest stand-in for the CDX search endpoint. lookup is called with
-// the request's url+closest query params (closest is empty when the
-// production code asked for the most recent snapshot via limit=-1).
-// A non-empty timestamp encodes one data row; an empty timestamp
-// encodes "no results".
+// fetcherWithMockedWayback returns a Fetcher whose CDXURL points at an
+// httptest server. lookup gets the request's url+closest params and
+// returns one (timestamp, original) row; empty timestamp = no match.
 func fetcherWithMockedWayback(t *testing.T, lookup func(target, closest string) (timestamp, original string)) *Fetcher {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -82,9 +79,6 @@ func TestFetcher_OriginFailFallsBackToArchive(t *testing.T) {
 	origin := httptest.NewServer(statusHandler(http.StatusNotFound))
 	t.Cleanup(origin.Close)
 
-	// snap stands in for both the CDX-returned snapshot URL and the
-	// follow-up GET; its handler ignores path so any constructed URL
-	// reaching it returns the snapshot body.
 	snap := httptest.NewServer(originHandler("<html>snapshot body</html>"))
 	t.Cleanup(snap.Close)
 
@@ -94,8 +88,6 @@ func TestFetcher_OriginFailFallsBackToArchive(t *testing.T) {
 		}
 		return "", ""
 	})
-	// Re-route the constructed snapshot URL at snap instead of the
-	// real wayback host.
 	f.SnapshotPrefix = snap.URL + "/"
 
 	res, err := f.Fetch(context.Background(), origin.URL, time.Time{})
@@ -153,7 +145,7 @@ func TestFetcher_DateTargetedSnapshotIsPreferred(t *testing.T) {
 		if closest == publishedAt.UTC().Format("20060102") {
 			return "20180806000000", origin.URL
 		}
-		if closest == "" { // production sets limit=-1 instead of closest
+		if closest == "" {
 			return "20260101000000", origin.URL
 		}
 		return "", ""
@@ -178,9 +170,7 @@ func TestFetcher_DateTargetedSnapshotIsPreferred(t *testing.T) {
 	}
 }
 
-// TestFetcher_CDXFiltersStatus200 verifies the production lookup asks
-// CDX to filter to statuscode:200, so an archived 404 page never
-// becomes archive_url.
+// Pins the statuscode:200 filter so an archived 404 never becomes archive_url.
 func TestFetcher_CDXFiltersStatus200(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The Wayback **Availability API** has a documented habit of returning empty `archived_snapshots: {}` for URLs that are clearly archived. Confirmed in our most recent enrich run (zero `archive_url` updates) and via direct curl probes. Switch `archiveLookup` to the **CDX server** with `&closest=&filter=statuscode:200`, which gives us the same "snapshot near publication date, otherwise the closest 200 snapshot" semantic on a more reliable endpoint.

Changes:
- `archiveLookup` queries `cdx/search/cdx?output=json&fl=timestamp,original&filter=statuscode:200` plus `closest=YYYYMMDD&limit=1` (date-targeted) or `limit=-1&fastLatest=true` (most recent).
- `Fetcher.AvailabilityURL` → `Fetcher.CDXURL`. Added `Fetcher.SnapshotPrefix` so the fallback-path test can route the constructed snapshot URL at an `httptest` server.
- Tests mock CDX JSON (`[[headers], [row]]`); added one to pin the `statuscode:200` filter.

SDK: evaluated `electrologue/wayback/cdx` (no `closest` parameter, hardcodes http://, reflection-based parsing, 0 stars, last touched Feb 2023) and `zomasec/webarchive` (wrong tool — pentesting domain crawler). Hand-rolled is ~50 lines and avoids the gotchas.
