### PR TITLE
fix: address golangci-lint findings

### DIFF
--- a/extract.go
+++ b/extract.go
@@ -1,14 +1,18 @@
+// Package postmortems extracts, parses, validates, and represents incident
+// postmortems stored as Markdown files with YAML front matter.
 package postmortems
 
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"regexp"
+	"time"
 
 	guuid "github.com/google/uuid"
 )
@@ -36,7 +40,7 @@ type ImportReport struct {
 // already exists in dir are skipped, so previously enriched fields are
 // preserved. The returned report lists freshly-saved entries so callers
 // can chain follow-up work without rescanning the directory.
-func ExtractPostmortems(loc string, dir string) (*ImportReport, error) {
+func ExtractPostmortems(ctx context.Context, loc string, dir string) (*ImportReport, error) {
 	posts, err := ValidateDir(dir)
 	if err != nil {
 		return nil, err
@@ -53,15 +57,22 @@ func ExtractPostmortems(loc string, dir string) (*ImportReport, error) {
 	}
 
 	var data []byte
-	if isURL(loc) {
-		// #nosec G107
-		resp, err := http.Get(loc)
-		if err != nil {
-			return nil, fmt.Errorf("could not get %q: %w", loc, err)
+	switch {
+	case isURL(loc):
+		reqCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+		req, rerr := http.NewRequestWithContext(reqCtx, http.MethodGet, loc, nil)
+		if rerr != nil {
+			return nil, fmt.Errorf("could not build request for %q: %w", loc, rerr)
+		}
+		// #nosec G107 -- loc is supplied by the operator running the importer.
+		resp, gerr := http.DefaultClient.Do(req)
+		if gerr != nil {
+			return nil, fmt.Errorf("could not get %q: %w", loc, gerr)
 		}
 		defer func() {
-			if err := resp.Body.Close(); err != nil {
-				log.Warnw("failed to close response body", "error", err)
+			if cerr := resp.Body.Close(); cerr != nil {
+				log.Warnw("failed to close response body", "error", cerr)
 			}
 		}()
 
@@ -69,12 +80,12 @@ func ExtractPostmortems(loc string, dir string) (*ImportReport, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not read response body: %w", err)
 		}
-	} else if isFile(loc) {
+	case isFile(loc):
 		data, err = os.ReadFile(loc) // #nosec G304
 		if err != nil {
 			return nil, fmt.Errorf("error opening file %q: %w", loc, err)
 		}
-	} else {
+	default:
 		return nil, fmt.Errorf("%q is not a file or a url", loc)
 	}
 

--- a/extract_test.go
+++ b/extract_test.go
@@ -1,6 +1,7 @@
 package postmortems
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,7 +22,7 @@ func TestExtractPostmortems_NewWaybackEntryIsPreUnwrapped(t *testing.T) {
 		t.Fatalf("write upstream: %v", err)
 	}
 
-	report, err := ExtractPostmortems(src, dir)
+	report, err := ExtractPostmortems(context.Background(), src, dir)
 	if err != nil {
 		t.Fatalf("ExtractPostmortems: %v", err)
 	}
@@ -37,7 +38,7 @@ func TestExtractPostmortems_NewWaybackEntryIsPreUnwrapped(t *testing.T) {
 	}
 
 	// Re-import the same upstream line: should be a no-op now.
-	report2, err := ExtractPostmortems(src, dir)
+	report2, err := ExtractPostmortems(context.Background(), src, dir)
 	if err != nil {
 		t.Fatalf("re-import: %v", err)
 	}
@@ -118,7 +119,7 @@ Body.
 		t.Fatalf("write upstream: %v", err)
 	}
 
-	report, err := ExtractPostmortems(src, dir)
+	report, err := ExtractPostmortems(context.Background(), src, dir)
 	if err != nil {
 		t.Fatalf("ExtractPostmortems: %v", err)
 	}
@@ -177,7 +178,7 @@ Long enriched body.
 		t.Fatalf("write upstream: %v", err)
 	}
 
-	report, err := ExtractPostmortems(src, dir)
+	report, err := ExtractPostmortems(context.Background(), src, dir)
 	if err != nil {
 		t.Fatalf("ExtractPostmortems: %v", err)
 	}

--- a/postmortem_test.go
+++ b/postmortem_test.go
@@ -2,7 +2,6 @@ package postmortems
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -30,11 +29,10 @@ func TestParse(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			f, err := os.Open(filepath.Join(tc.filepath))
+			f, err := os.Open(tc.filepath)
 			if err != nil {
 				t.Errorf("error opening postmortem: %v", err)
 				return
@@ -122,7 +120,6 @@ func TestEventDatePeriod(t *testing.T) {
 		{name: "range", pm: Postmortem{StartTime: mar15, EndTime: mar20}, want: "2024-03-15 \u2013 2024-03-20"},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if got := tc.pm.EventDatePeriod(); got != tc.want {

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -96,13 +96,12 @@ func TestHealthzCheckHandler(t *testing.T) {
 		},
 	}
 
-	r, err := http.NewRequest(http.MethodGet, "/healthz", nil)
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/healthz", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			w := httptest.NewRecorder()
@@ -161,7 +160,6 @@ func TestLoadPostmortem(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -205,7 +203,6 @@ func TestLoadPostmortems(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -342,7 +339,6 @@ func TestSummarizeMarkdown(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if got := summarizeMarkdown(tc.in, tc.max); got != tc.want {
@@ -411,7 +407,6 @@ func TestGetPostmortemsByCategory(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/tool/categories_test.go
+++ b/tool/categories_test.go
@@ -39,7 +39,6 @@ func TestMatchCategories(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := matchCategories(tc.body, tc.existing)

--- a/tool/enrich_test.go
+++ b/tool/enrich_test.go
@@ -554,12 +554,12 @@ func TestLooksLikeJunkDescription(t *testing.T) {
 			t.Errorf("looksLikeJunkDescription(%q) = false, want true", s)
 		}
 	}
-	real := []string{
+	realDescs := []string{
 		"On March 20, 2017, Discord experienced significant connectivity issues.",
 		"The Swedish warship Vasa embarked on its maiden voyage on August 10, 1628.",
 		"At 10:25 PM PDT, severe weather caused a utility power loss at a regional substation.",
 	}
-	for _, s := range real {
+	for _, s := range realDescs {
 		if looksLikeJunkDescription(s) {
 			t.Errorf("looksLikeJunkDescription(%q) = true, want false", s)
 		}

--- a/tool/fetch_test.go
+++ b/tool/fetch_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 func originHandler(body string) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(body))
 	}
 }
 
 func statusHandler(status int) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(status) }
+	return func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(status) }
 }
 
 // fetcherWithMockedWayback returns a Fetcher whose CDXURL points at an

--- a/tool/import.go
+++ b/tool/import.go
@@ -40,7 +40,7 @@ func RunImport(ctx context.Context, opts importOptions) (*importResult, error) {
 
 	opts.Logger.Info("import starting", "source", opts.Source, "dir", opts.Dir)
 
-	report, err := postmortems.ExtractPostmortems(opts.Source, opts.Dir)
+	report, err := postmortems.ExtractPostmortems(ctx, opts.Source, opts.Dir)
 	if err != nil {
 		return nil, fmt.Errorf("extract: %w", err)
 	}

--- a/urls_test.go
+++ b/urls_test.go
@@ -55,7 +55,6 @@ func TestCanonicalURL(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if got := CanonicalURL(tc.in); got != tc.want {


### PR DESCRIPTION
## Summary
The new golangci-lint workflow added stricter linters. This PR fixes the 11 findings so the lint check passes.

## Changes
- **copyloopvar (3)**: Removed redundant `tc := tc` aliases (no longer needed on Go 1.22+) in `postmortem_test.go`, `urls_test.go`, and `tool/categories_test.go`.
- **noctx (2)**: Replaced `http.Get` in `extract.go` and `http.NewRequest` in `server/handlers_test.go` with context-aware variants.
- **contextcheck (1)**: `ExtractPostmortems` now takes a `context.Context` parameter, propagated from `tool/import.go`'s `RunImport`.
- **revive package-comments (1)**: Added a package comment to `extract.go` (the canonical doc file for `package postmortems`).
- **revive redefines-builtin-id (1)**: Renamed `real` local var to `realDescs` in `tool/enrich_test.go`.
- **revive unused-parameter (2)**: Renamed unused `r *http.Request` to `_` in `tool/fetch_test.go` handler stubs.
- **gocritic ifElseChain (1)**: Rewrote URL/file dispatch in `extract.go` as a `switch`.
- **gocritic badCall (1)**: Removed pointless single-arg `filepath.Join` in `postmortem_test.go`.

## Verification
- `golangci-lint run -E bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert ./...` — 0 issues
- `go build ./...` — passes
- `go test ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)