### PR TITLE
fix: log unknown postmortem ids at debug, not warn

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -4,8 +4,10 @@ package server
 import (
 	"compress/flate"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"net/http"
 	"net/url"
 	"os"
@@ -789,7 +791,14 @@ func postmortemPageHandler(dir string) http.HandlerFunc {
 
 		pm, err := LoadPostmortem(dir, pmID+".md")
 		if err != nil {
-			l.Warnw("load postmortem", "pmid", pmID, zap.Error(err))
+			// pmID comes straight off the URL, so an unknown one is a routine
+			// 404 from a crawler or stale link. Only real read/parse failures
+			// are worth a warning.
+			if errors.Is(err, fs.ErrNotExist) {
+				l.Debugw("postmortem not found", "pmid", pmID)
+			} else {
+				l.Warnw("load postmortem", "pmid", pmID, zap.Error(err))
+			}
 			notFoundHandler(w, r)
 			return
 		}


### PR DESCRIPTION
`pmID` comes off the URL, so an unknown one is a routine 404 from a crawler or a stale link — not a warning. mist has been logging `load postmortem ... open data/dac13e0f-….md: no such file` at warn level for requests to IDs that have never existed.

Not-exist now logs at debug; real read/parse failures still warn.